### PR TITLE
Adds FutureWithDefault

### DIFF
--- a/storehaus-core/src/main/scala/com/twitter/storehaus/FutureWithDefault.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/FutureWithDefault.scala
@@ -1,0 +1,137 @@
+package com.twitter.storehaus
+
+import com.twitter.util.{Duration, Future, Try, Throw, Return, TimeoutException}
+
+import java.util.concurrent.atomic.{AtomicReference => AtomicRef, AtomicBoolean}
+
+object FutureWithDefault {
+  def const[T](t: Try[T]) = new FutureWithDefault(Future.const(t)) {
+      def onTimeout = t
+    }
+
+  def value[T](t: T) = const(Return(t))
+
+  def onTimeout[T](f: Future[T])(to: => Try[T]) =
+    new FutureWithDefault(f) { lazy val onTimeout = to }
+}
+
+/**
+ *
+ */
+abstract class FutureWithDefault[+T](val future: Future[T]) {
+  // This is what you override:
+  protected def onTimeout: Try[T]
+
+  ////////////////////////////////////////////
+  // Be super careful about changing anything below
+  ////////////////////////////////////////////
+
+  protected val timedoutRef = new AtomicBoolean(false)
+  def timedout: Boolean = timedoutRef.get
+
+  // the variance is messing up the types, here, casting for now
+  protected def process(t: Try[_]): Try[_] = {
+    t.rescue {
+      case (t: TimeoutException) => {
+        // We're done:
+        future.cancel
+        timedoutRef.set(true)
+        onTimeout
+      }
+      case (x: Throwable) => {
+        if(future.isCancelled) {
+          timedoutRef.set(true)
+          onTimeout
+        }
+        else {
+          Throw(x)
+        }
+      }
+    }
+  }
+
+  /** Wait a period of time, or return the timeout value
+   * if you get a timeout, the future is canceled.
+   * always returns the same value
+   */
+  def get(d: Duration): Try[T] = process(future.get(d)).asInstanceOf[Try[T]]
+
+  /** If the result is ready, get it, otherwise get the timeout
+   */
+  def getNow: Try[T] =
+    future
+      .poll.map { t => process(t) }
+      .getOrElse {
+        future.cancel
+        timedoutRef.set(true)
+        onTimeout
+      }.asInstanceOf[Try[T]]
+
+  def flatMap[U](fn: T => FutureWithDefault[U]): FutureWithDefault[U] = {
+    val resref = new AtomicRef[() => Try[U]]() // Initially null
+    val fnref = new AtomicRef[T => FutureWithDefault[U]](fn)
+
+    val nextFuture = future.flatMap { t =>
+      // Get the future, if this is the first call:
+      if (fnref.compareAndSet(fn, null)) {
+        //fn has not yet been called
+        val nextFWT = fn(t)
+        // Send the timeout function through
+        resref.set({ () => nextFWT.getNow })
+        nextFWT.future
+      }
+      else {
+        // someone called onTimeout
+        Future.exception(new Exception("we timed out waiting"))
+      }
+    }
+    // Don't capture any refs in here other than future, and one we will null
+    // if Future leaks memory by holding refs, that's future's fault
+    new FlatMappedFutureWithDefault[T,U](nextFuture, (this, fn, resref, fnref))
+  }
+
+  def map[U](fn: T => U): FutureWithDefault[U] =
+    flatMap { (t: T) => FutureWithDefault.value(fn(t)) }
+
+  // The result is considered to have timedout is either this or u did
+  def join[U](u: FutureWithDefault[U]): FutureWithDefault[(T,U)] =
+    FutureWithDefault.onTimeout(future.join(u.future)) {
+      for(tot <- getNow; tou <- u.getNow) yield (tot, tou)
+    }
+  // If this doesn't return, call u.getNow
+  def orGetNow[U >:T](u: FutureWithDefault[U]): FutureWithDefault[U] =
+    FutureWithDefault.onTimeout[U](future)(u.getNow)
+}
+
+private class FlatMappedFutureWithDefault[T,U](override val future: Future[U],
+  var state: (FutureWithDefault[T],
+              T => FutureWithDefault[U],
+              AtomicRef[() => Try[U]],
+              AtomicRef[T => FutureWithDefault[U]]))
+  extends FutureWithDefault[U](future) {
+
+  // Make sure we eventually null out state:
+  future.respond { tu: Try[U] =>
+    //Realize the on timeout so it is safe to move with life and null out gc
+    this.onTimeout
+  }
+
+  lazy val onTimeout = {
+    val (prev, fn, resref, fnref) = state
+    // Null out the state to avoid holding too long and preventing GC
+    state = null
+    if(fnref.compareAndSet(fn, null)) {
+      timedoutRef.set(true)
+      // No one has yet called fn, so we are safe to:
+      prev.getNow.flatMap { t => fn(t).getNow }
+    }
+    else {
+      // We have already called fn so we have setup a timeout value:
+      var timeoutFn: Function0[Try[U]] = null
+      //Spin because fn is not blocking, we should have the value:
+      while(null == timeoutFn) { timeoutFn = resref.get() }
+      timeoutFn()
+    }
+  }
+}
+

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/FutureWithTimeoutProps.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/FutureWithTimeoutProps.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Gen.choose
+import org.scalacheck.Prop._
+
+import com.twitter.util.{Future, Return, Duration}
+import java.util.concurrent.TimeUnit
+
+object FutureWithDefaultProperties extends Properties("FutureWithDefault") {
+
+  implicit def arbFut[T](implicit arb: Arbitrary[T]): Arbitrary[FutureWithDefault[T]] = {
+    Arbitrary {
+      for(t0 <- arb.arbitrary; t1 <- arb.arbitrary)
+        yield FutureWithDefault.onTimeout(Future.value(t0))(Return(t1))
+    }
+  }
+  property("associativity") = forAll { (fm: FutureWithDefault[Int]) =>
+    val fn1 = { x: Int => FutureWithDefault.value(10*x) }
+    val fn2 = { x: Int => FutureWithDefault.value(42*x) }
+    fm.flatMap(fn1).flatMap(fn2).getNow ==
+      fm.flatMap { fn1.andThen { _.flatMap(fn2) } }.getNow
+  }
+
+  property("map is consistent with flatMap") = forAll { (fm: FutureWithDefault[Int]) =>
+    fm.map { _ * 10 }.getNow == fm.flatMap { i => FutureWithDefault.value(10*i) }.getNow
+  }
+
+  property("Constants are returned") = forAll { (i: Int) =>
+    FutureWithDefault.value(i).getNow == Return(i) &&
+      FutureWithDefault.value(i).get(Duration(1, TimeUnit.SECONDS)) == Return(i)
+  }
+}


### PR DESCRIPTION
This addresses the following use case:

store0 has worse data than store1, but is faster.

Suppose:

``` scala
trait Store[K,V] {
  def get(k: K): FutureWithDefault[Option[V]]
}

store1.get(k).orGetNow(store0.get(k))
```
