### PR TITLE
Adds ReadableStore.find

### DIFF
--- a/storehaus-core/src/main/scala/com/twitter/storehaus/SearchingReadableStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/SearchingReadableStore.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus
+
+import com.twitter.util.Future
+
+/**
+  * Returns a ReadableStore that attempts reads out of the supplied
+  * Seq[ReadableStore] in order and returns the first non-exceptional
+  * value that satisfies the supplied predicate.
+  *
+  * multiGet attempts a full multiGet of the first store, then follows
+  * up on missing or failed keys with individual gets to the
+  * underlying stores (as failures for each key can happen at
+  * different times).
+  */
+
+class SearchingReadableStore[-K, +V](stores: Seq[ReadableStore[K, V]])(pred: Option[V] => Boolean) extends ReadableStore[K, V] {
+  override def get(k: K) = FutureOps.find(stores.toStream.map(_.get(k)))(pred)
+  override def multiGet[K1 <: K](ks: Set[K1]) = {
+    val tail = stores.tail
+    stores.head.multiGet(ks).map { case (k, v) =>
+        k -> FutureOps.find(v #:: tail.toStream.map { _.get(k) })(pred)
+    }
+  }
+}

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/ReplicatedStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/ReplicatedStoreProperties.scala
@@ -19,8 +19,6 @@ package com.twitter.storehaus
 import org.scalacheck.Properties
 
 object ReplicatedStoreProperties extends Properties("ReplicatedStore") {
-  import StoreProperties.storeTest
-
   property("ReplicatedStore test") =
-    storeTest(new ReplicatedStore(Stream.continually(new JMapStore[String, Int]).take(100).toSeq))
+    StoreProperties.storeTest(Store.first(Stream.continually(new JMapStore[String, Int]).take(100).toSeq))
 }

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/SearchingReadableStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/SearchingReadableStoreProperties.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+object SearchingReadableStoreProperties extends Properties("SearchingReadableStore") {
+  /**
+    * The SearchingReadableStore returned by ReadableStore.find always
+    * looks at substores from left to right. This test checks that the
+    * store keeps searching until it finds its first non-None value.
+    */
+  property("ReadableStore.find works as expected") =
+    forAll { (m1: Map[String, Int], m2: Map[String, Int]) =>
+      val store = ReadableStore.find(Seq(ReadableStore.fromMap(m1), ReadableStore.fromMap(m2)))(_.isDefined)
+      val leftGet = store.multiGet(m1.keySet).mapValues(_.get)
+      val rightGet = store.multiGet(m2.keySet).mapValues(_.get)
+      leftGet == m1.mapValues(Some(_)) && rightGet.forall { case (k, v) => v == (m2 ++ m1).get(k) }
+    }
+}


### PR DESCRIPTION
`ReadableStore.find` is a `ReadableStore` combinator that lazily retrieves values from an ordered sequence of `ReadableStore`s. A value is returned if

a) its wrapping Future executes successfully, and 
b) its contained optional value passes the supplied predicate.
