### PR TITLE
Mysql test fixes

### DIFF
--- a/storehaus-mysql/src/test/scala/com/twitter/storehaus/mysql/MySQLStoreProperties.scala
+++ b/storehaus-mysql/src/test/scala/com/twitter/storehaus/mysql/MySQLStoreProperties.scala
@@ -106,7 +106,7 @@ object MySQLStoreProperties extends Properties("MySQLStore") {
     withStore(putAndMultiGetStoreTest(_), "text", "blob", true)
 
   private def withStore[T](f: MySQLStore => T, kColType: String, vColType: String, multiGet: Boolean = false): T = {
-    val client = Client("localhost:3306", "storehaususer", "test1234", "storehaus_test")
+    val client = Client("localhost:3306", "storehaususer", "test1234", "storehaus_test", Level.WARNING)
     // these should match mysql setup used in .travis.yml
 
     val tableName = "storehaus-mysql-"+kColType+"-"+vColType + ( if (multiGet) { "-multiget" } else { "" } )


### PR DESCRIPTION
use separate table name for each test property (to avoid concurrently running tests sharing the same table)

use Await.result instead of get (to remove build warnings)

enable finagle-mysql logging 
