### PR TITLE
Sync finagle versions ( and all future versions )

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -151,7 +151,7 @@ object StorehausBuild extends Build {
   ).settings(
     name := "storehaus-mysql",
     previousArtifact := youngestForwardCompatible("mysql"),
-    libraryDependencies += Finagle.module("mysql")
+    libraryDependencies += Finagle.module("mysql", "6.2.1") // tests fail with the latest
   ).dependsOn(storehausCore % "test->test;compile->compile")
 
   lazy val storehausRedis = Project(

--- a/project/Finagle.scala
+++ b/project/Finagle.scala
@@ -5,7 +5,7 @@ package storehaus
  *  dependency */
 object Finagle {
   import sbt._
-  val version = "6.3.0"
-  def module(name: String) =
+  val LatestVersion = "6.3.0"
+  def module(name: String, version: String = LatestVersion) =
     "com.twitter" %% "finagle-%s".format(name) % version
 }


### PR DESCRIPTION
Currently we have 3 storehaus modules that depend on finagle clients
- finagle-memcached 6.3.0
- finagle-redis 6.2.0
- finagle-mysql 6.2.1

This changeset syncs them to all to 6.3.0 and provides an common interface for doing so that reduces the build maintenance of keeping them in sync in the future 

`libraryDependencies += Finagle.module("foo")` 
