### PR TITLE
UpdatableStore

### DIFF
--- a/storehaus-core/src/main/scala/com/twitter/storehaus/ConcurrentHashMapStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/ConcurrentHashMapStore.scala
@@ -16,6 +16,7 @@
 
 package com.twitter.storehaus
 
+import com.twitter.util.Future
 import java.util.concurrent.{ ConcurrentHashMap => JConcurrentHashMap }
 
 /** A simple JMapStore whose underlying store is a Java ConcurrentHashMap
@@ -37,9 +38,9 @@ class ConcurrentHashMapStore[K, V] extends JMapStore[K, V] {
     val updated = fn(original)
     val success =
       (original, updated) match {
-        case (Some(from), Some(to)) => jstore.replace(k, from, to)
-        case (Some(from), None) => jstore.remove(k, from)
-        case (None, Some(to)) => jstore.putIfAbsent(k, to) == null
+        case (Some(_), Some(_)) => jstore.replace(k, original, updated)
+        case (Some(_), None) => jstore.remove(k, original)
+        case (None, Some(_)) => jstore.putIfAbsent(k, updated) == null
         case (None, None) => !jstore.containsKey(k)
       }
 

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/JMapStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/JMapStore.scala
@@ -25,7 +25,7 @@ import java.util.{ Map => JMap, HashMap => JHashMap }
  *  @author Oscar Boykin
  *  @author Sam Ritchie
  */
-class JMapStore[K, V] extends Store[K, V] {
+class JMapStore[K, V] extends UpdatableStore[K, V] {
   protected val jstore: JMap[K, Option[V]] = new JHashMap[K, Option[V]]()
   protected def storeGet(k: K): Option[V] = {
     val stored = jstore.get(k)
@@ -39,4 +39,6 @@ class JMapStore[K, V] extends Store[K, V] {
     if (kv._2.isEmpty) jstore.remove(kv._1) else jstore.put(kv._1, kv._2)
     Future.Unit
   }
+
+  def update(k : K)(fn : Option[V] => Option[V]) = put((k, fn(storeGet(k))))
 }

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/UpdatableStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/UpdatableStore.scala
@@ -16,6 +16,8 @@
 
 package com.twitter.storehaus
 
+import com.twitter.util.Future
+
 trait UpdatableStore[K,V] extends Store[K,V] {
   def update(k : K)(fn : Option[V] => Option[V]) : Future[Unit]
 }

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/UpdatableStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/UpdatableStore.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus
+
+trait UpdatableStore[K,V] extends Store[K,V] {
+  def update(k : K)(fn : Option[V] => Option[V]) : Future[Unit]
+}

--- a/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisUpdatableStore.scala
+++ b/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisUpdatableStore.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.redis
+
+import com.twitter.finagle.redis.TransactionalClient
+import com.twitter.util.{Future, Time}
+import com.twitter.storehaus.UpdatableStore
+import com.twitter.finagle.redis.protocol.{Set => SetCommand, Del}
+import org.jboss.netty.buffer.ChannelBuffer
+
+
+class RedisUpdatableStore(val txnClient: TransactionalClient, ttl: Option[Time])
+  extends RedisStore(txnClient, ttl) with UpdatableStore[ChannelBuffer, ChannelBuffer] {
+
+    def update(k : ChannelBuffer)(fn : Option[ChannelBuffer] => Option[ChannelBuffer]) =
+       txnClient.watch(List(k)).flatMap { unit =>
+         txnClient.get(k).flatMap { oldValue =>
+           val command = fn(oldValue) match {
+             case Some(v) => SetCommand(k, v)
+             case None => Del(List(k))
+           }
+
+           txnClient.transaction(List(command)).flatMap { replies => Future.Unit }
+         }
+       }
+}


### PR DESCRIPTION
Sketching out an UpdatableStore trait as described in #113. Extends JMapStore and ConcurrentHashMapStore to be UpdateableStores, and adds a new RedisUpdatableStore that uses the TransactionalClient.

Totally untested so far.

Todo:
- [ ] add tests
- [ ] memcache support
- [ ] mysql support
- [ ] combinator to retry on failed updates
- [ ] ConvertedUpdatableStore
- [ ] ShardedUpdatableStore
- [ ] EnrichedUpdatableStore
- [ ] combinator to turn any UpdatableStore + a monoid into a MergeableStore
