### PR TITLE
Writeable stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,22 @@ Storehaus's core module defines three traits; a read-only `ReadableStore` a writ
 ```scala
 package com.twitter.storehaus
 
+import com.twitter.util.{ Closable, Future, Time }
+
 trait ReadableStore[-K, +V] extends Closeable {
   def get(k: K): Future[Option[V]]
   def multiGet[K1 <: K](ks: Set[K1]): Map[K1, Future[Option[V]]]
-  override def close { }
+  override def close(time: Time) = Future.Unit
 }
 
-trait WritableStore[-K, V] {
-  def put(kv: (K, Option[V])): Future[Unit] = multiPut(Map(kv)).apply(kv._1)
-  def multiPut[K1 <: K](kvs: Map[K1, Option[V]]): Map[K1, Future[Unit]] =
+trait WritableStore[-K, -V] {
+  def put(kv: (K, V)): Future[Unit] = multiPut(Map(kv)).apply(kv._1)
+  def multiPut[K1 <: K](kvs: Map[K1, V]): Map[K1, Future[Unit]] =
     kvs.map { kv => (kv._1, put(kv)) }
+  override def close(time: Time) = Future.Unit
 }
 
-trait Store[-K, V] extends ReadableStore[K, V] with WritableStore[K, V]
+trait Store[-K, V] extends ReadableStore[K, V] with WritableStore[K, Option[V]]
 ```
 
 The `ReadableStore` trait uses the `Future[Option[V]]` return type to communicate one of three states about each value. A value is either

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/Store.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/Store.scala
@@ -89,4 +89,4 @@ object Store {
 
 /** Main trait for stores can be both read from and written to
  */
-trait Store[-K, V] extends ReadableStore[K, V] with WritableStore[K, V]
+trait Store[-K, V] extends ReadableStore[K, V] with WritableStore[K, Option[V]]

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/WritableStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/WritableStore.scala
@@ -22,14 +22,14 @@ import com.twitter.util.{ Closable, Duration, Future, Time }
  * Instances may implement EITHER put, multiPut or both. The default implementations
  * are in terms of each other.
  */
-trait WritableStore[-K, V] extends Closable {
+trait WritableStore[-K, -V] extends Closable {
   /**
    * replace a value
    * Delete is the same as put((k,None))
    */
-  def put(kv: (K, Option[V])): Future[Unit] = multiPut(Map(kv)).apply(kv._1)
+  def put(kv: (K, V)): Future[Unit] = multiPut(Map(kv)).apply(kv._1)
   /** Replace a set of keys at one time */
-  def multiPut[K1 <: K](kvs: Map[K1, Option[V]]): Map[K1, Future[Unit]] =
+  def multiPut[K1 <: K](kvs: Map[K1, V]): Map[K1, Future[Unit]] =
     kvs.map { kv => (kv._1, put(kv)) }
 
   /** Close this store and release any resources.
@@ -41,6 +41,6 @@ trait WritableStore[-K, V] extends Closable {
 /**
  * Trait for building mutable store with TTL.
  */
-trait WithPutTtl[K, V, S <: WritableStore[K, V]] {
+trait WithPutTtl[K, V, S <: WritableStore[K, Option[V]]] {
   def withPutTtl(ttl: Duration): S
 }


### PR DESCRIPTION
This should address both #177 and #91. Since `WriteableStore` was extracted from then remixed back into the `Store` interface, this should be a non-breaking change. The upshot is that we can have write-only stores. yay!
