### PR TITLE
my little proxy

### DIFF
--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableProxy.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableProxy.scala
@@ -22,7 +22,7 @@ import com.twitter.util.{ Future, Time }
 
 /** Proxy for Mergeables. Methods not overrided in extensions will be forwared to Proxied
  *  self member */
-trait MergeableProxy[K, V] extends Proxied[Mergeable[K,V]] with Mergeable[K, V] {
+trait MergeableProxy[K, V] extends Mergeable[K, V] with Proxied[Mergeable[K,V]] {
   override def semigroup: Semigroup[V] = self.semigroup
   override def merge(kv: (K, V)): Future[Option[V]] = self.merge(kv)
   override def multiMerge[K1 <: K](kvs: Map[K1, V]): Map[K1, Future[Option[V]]] = self.multiMerge(kvs)
@@ -31,7 +31,7 @@ trait MergeableProxy[K, V] extends Proxied[Mergeable[K,V]] with Mergeable[K, V] 
 
 /** Proxy for MergeableStoress. Methods not overrided in extensions will be forwared to Proxied
  *  self member */
-trait MergeableStoreProxy[K, V] extends Proxied[MergeableStore[K, V]] with MergeableStore[K, V] {
+trait MergeableStoreProxy[K, V] extends MergeableStore[K, V] with Proxied[MergeableStore[K, V]] {
   override def semigroup: Semigroup[V] = self.semigroup
   override def merge(kv: (K, V)): Future[Option[V]] = self.merge(kv)
   override def multiMerge[K1 <: K](kvs: Map[K1, V]): Map[K1, Future[Option[V]]] = self.multiMerge(kvs)

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/Proxy.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/Proxy.scala
@@ -60,7 +60,7 @@ trait Proxied[T] {
 /** A proxy for ReadableStores. Methods not overridden in extensions will be forwarded to
  *  Proxied self member
  */
-trait ReadableStoreProxy[K, V] extends Proxied[ReadableStore[K, V]] with ReadableStore[K, V] {
+trait ReadableStoreProxy[K, V] extends ReadableStore[K, V] with Proxied[ReadableStore[K, V]]  {
   override def get(k: K): Future[Option[V]] = self.get(k)
   override def multiGet[K1 <: K](ks: Set[K1]): Map[K1, Future[Option[V]]] = self.multiGet(ks)
   override def close(time: Time) = self.close(time)
@@ -68,7 +68,7 @@ trait ReadableStoreProxy[K, V] extends Proxied[ReadableStore[K, V]] with Readabl
 
 /** A Proxy for WritableStores. Methods not overriden in extensions will be forwarded to
  *  Proxied self member */
-trait WritableStoreProxy[K, V] extends Proxied[WritableStore[K, V]] with WritableStore[K, V] {
+trait WritableStoreProxy[K, V] extends WritableStore[K, V] with Proxied[WritableStore[K, V]]  {
   override def put(kv: (K, V)): Future[Unit] = self.put(kv)
   override def multiPut[K1 <: K](kvs: Map[K1, V]): Map[K1, Future[Unit]] = self.multiPut(kvs)
   override def close(time: Time) = self.close(time)
@@ -76,7 +76,7 @@ trait WritableStoreProxy[K, V] extends Proxied[WritableStore[K, V]] with Writabl
 
 /** A Proxy for Stores. Methods not overrided in extensions will be forwared to Proxied
  *  self member */
-trait StoreProxy[K, V] extends Proxied[Store[K, V]] with Store[K, V] {
+trait StoreProxy[K, V] extends Store[K, V] with Proxied[Store[K, V]] {
   override def put(kv: (K, Option[V])): Future[Unit] = self.put(kv)
   override def multiPut[K1 <: K](kvs: Map[K1, Option[V]]): Map[K1, Future[Unit]] = self.multiPut(kvs)
   override def get(k: K): Future[Option[V]] = self.get(k)


### PR DESCRIPTION
Factored proxy idea out of instrumented branch as its useful in many other context for store extensions. I put an example in the scala doc in the core module and defined proxy interfaces for {Readable,Writable,Mergeabl}Stores. I changed the names a bit from my other branch but I can update that branch after this gets reviewed.

The general idea is that there's a proxy implementation of `Proxied[T]` defined for each core store type `T`. 

Combinators and other custom functionality can now create a new `XXXProxy` for an instance of `XXX`  overriding only what they need. All other method calls are automatically forwarded to the proxied instance
