### PR TITLE
Add out of retries exception to retrying store

### DIFF
--- a/storehaus-core/src/main/scala/com/twitter/storehaus/FutureOps.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/FutureOps.scala
@@ -26,11 +26,19 @@ import com.twitter.util.{ Future, Throw, Return }
  */
 class MissingValueException[K](val key: K) extends RuntimeException("Missing value for " + key)
 
+/**
+ * This is thrown when a retryable store runs out of retries
+ * when looking for a key.
+ */
+class RetriesExhaustedException[K](val key: K) extends RuntimeException("Retries exhausted for key " + key)
+
 /** Some combinators on Futures or Seqs of Futures that are used internally
  * These should arguably exist in util-core.
  */
 object FutureOps {
   def missingValueFor[K](k: K) = Future.exception(new MissingValueException(k))
+
+  def retriesExhaustedFor[K](k: K) = Future.exception(new RetriesExhaustedException(k))
 
   /** Kleisli operator for Future[Option[_]] Monad.  I knew it would come to this. */
   def combineFOFn[A, B, C](f1: A => Future[Option[B]], f2: B => Future[Option[C]])(a: A): Future[Option[C]] = {

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/RetryingStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/RetryingStore.scala
@@ -30,7 +30,7 @@ class RetryingReadableStore[-K, +V](store: ReadableStore[K, V], backoffs: Iterab
       case Return(t) => Future.value(t)
       case Throw(e) =>
         backoffs.headOption match {
-          case None => FutureOps.missingValueFor(k)
+          case None => FutureOps.retriesExhaustedFor(k)
           case Some(interval) => interval match {
             case Duration.Zero => getWithRetry(k, backoffs.tail)
             case Duration.Top => FutureOps.missingValueFor(k)


### PR DESCRIPTION
Addresses https://github.com/twitter/storehaus/issues/193

Not sure what the original interpretation of `MissingValueException` was. Looks like we throw that only if we ever hit Duration.Top in the backoffs list? cc @ximyu
