### PR TITLE
Exceptions on the cache-store should be ignored for Read/WriteThroughStore

### DIFF
--- a/storehaus-core/src/main/scala/com/twitter/storehaus/WriteThroughStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/WriteThroughStore.scala
@@ -40,16 +40,16 @@ class WriteThroughStore[K, V](backingStore: Store[K, V], cache: Store[K, V], inv
 
   override def put(kv: (K, Option[V])): Future[Unit] = mutex.acquire.flatMap { p =>
     // write key to backing store first
-    backingStore.put(kv).flatMap { u: Unit =>
+    backingStore.put(kv).flatMap { _ =>
       // now write key to cache, best effort
-      cache.put(kv) onFailure { case x: Exception => u }
-    } onFailure { case x: Exception =>
+      cache.put(kv) rescue { case x: Exception => Future.Unit }
+    } rescue { case x: Exception =>
       // write to backing store failed
       // now optionally invalidate the key in cache, best effort
       if (invalidate) {
-        cache.put((kv._1, None)).flatMap { u: Unit => throw x } onFailure { throw x }
+        cache.put((kv._1, None)) transform { _ => Future.exception(x) }
       } else {
-        throw x
+        Future.exception(x)
       }
     } ensure {
       p.release
@@ -61,7 +61,7 @@ class WriteThroughStore[K, V](backingStore: Store[K, V], cache: Store[K, V], inv
       // write keys to backing store first
       val storeResults : Map[K1, Future[Either[Unit, Exception]]] =
         backingStore.multiPut(kvs).map { case (k, f) =>
-          (k, f.map { u: Unit => Left(u) }.onFailure { case x: Exception => Right(x) })
+          (k, f.map { u: Unit => Left(u) }.rescue { case x: Exception => Future.value(Right(x)) })
         }
 
       // perform cache operations based on how writes to backing store go

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/RandomExceptionStore.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/RandomExceptionStore.scala
@@ -1,0 +1,17 @@
+package com.twitter.storehaus
+
+import com.twitter.util.Future
+
+import scala.util.Random
+
+class RandomExceptionStore[K, V](f: Float = 0.5f) extends ConcurrentHashMapStore[K, V] {
+  override def get(k: K): Future[Option[V]] = {
+    if (Random.nextFloat() < f) Future.exception(new RuntimeException())
+    else super.get(k)
+  }
+
+  override def put(kv: (K, Option[V])): Future[Unit] = {
+    if (Random.nextFloat() < f) Future.exception(new RuntimeException())
+    else super.put(kv)
+  }
+}

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/ReadThroughStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/ReadThroughStoreProperties.scala
@@ -16,6 +16,8 @@
 
 package com.twitter.storehaus
 
+import com.twitter.util.Future
+
 import org.scalacheck.Properties
 import org.scalacheck.Prop._
 
@@ -25,6 +27,12 @@ object ReadThroughStoreProperties extends Properties("ReadThroughStoreProperties
   property("ReadThroughStore obeys the ReadableStore laws") =
     readableStoreLaws[String, Int] { m =>
       new ReadThroughStore(ReadableStore.fromMap(m), new ConcurrentHashMapStore[String,Int])
+    }
+
+  property("ReadThroughStore should ignore exceptions on the cache-store") =
+    readableStoreLaws[String, Int] { m =>
+      new ReadThroughStore(ReadableStore.fromMap(m),
+        new RandomExceptionStore())
     }
 }
 

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/WriteThroughStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/WriteThroughStoreProperties.scala
@@ -32,5 +32,11 @@ object WriteThroughStoreProperties extends Properties("WriteThroughStoreProperti
       new WriteThroughStore(new ConcurrentHashMapStore[String,Int],
         new ConcurrentHashMapStore[String,Int], false)
     }
+
+  property("WriteThroughStore should ignore on the cache-store") =
+    storeTest {
+      new WriteThroughStore(new ConcurrentHashMapStore[String, Int],
+        new RandomExceptionStore())
+    }
 }
 


### PR DESCRIPTION
I'm not sure that those behaviors are intended or not.
But using `Future#respond` variants like `.onFailure { case x: Exception => storeValue }` are meaningless.
(`onFailure` won't transform into new `Future`, it will simply register a callback)

Use `Future#transform` variants instead of `Future#respond`s on XxxThroughStore
