### PR TITLE
Memcache mergeable - use semigroup

### DIFF
--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.storehaus.memcache
 
-import com.twitter.algebird.Monoid
+import com.twitter.algebird.Semigroup
 import com.twitter.bijection.{ Bijection, Codec, Injection }
 import com.twitter.bijection.netty.Implicits._
 import com.twitter.conversions.time._
@@ -92,10 +92,10 @@ object MemcacheStore {
   /**
     * Returns a Memcache-backed MergeableStore[K, V] that uses
     * implicitly-supplied Injection instances from K and V ->
-    * Array[Byte] to manage type conversion. The Monoid[V] is also
+    * Array[Byte] to manage type conversion. The Semigroup[V] is also
     * pulled in implicitly.
     */
-  def mergeable[K: Codec, V: Codec: Monoid](client: Client, keyPrefix: String,
+  def mergeable[K: Codec, V: Codec: Semigroup](client: Client, keyPrefix: String,
     ttl: Duration = DEFAULT_TTL, flag: Int = DEFAULT_FLAG): MergeableStore[K, V] =
     MergeableStore.fromStore(
       MemcacheStore.typed(client, keyPrefix, ttl, flag)


### PR DESCRIPTION
Addresses https://github.com/twitter/storehaus/issues/250

There is a cas-based mergeable memcache store. Adding a hook for that as well might help folks try it out. Will send that in a separate change.
https://github.com/twitter/storehaus/blob/develop/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
