### PR TITLE
storehaus-memcache: pass ttl for MergeableMemcacheStore CAS calls

### DIFF
--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
@@ -113,7 +113,7 @@ object MemcacheStore {
     MergeableMemcacheStore[K, V](client, ttl, flag, retries)(kfn)(inj, implicitly[Semigroup[V]])
 }
 
-class MemcacheStore(val client: Client, ttl: Duration, flag: Int)
+class MemcacheStore(val client: Client, val ttl: Duration, flag: Int)
   extends Store[String, ChannelBuffer]
   with WithPutTtl[String, ChannelBuffer, MemcacheStore]
 {

--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
@@ -113,7 +113,7 @@ object MemcacheStore {
     MergeableMemcacheStore[K, V](client, ttl, flag, retries)(kfn)(inj, implicitly[Semigroup[V]])
 }
 
-class MemcacheStore(val client: Client, val ttl: Duration, flag: Int)
+class MemcacheStore(val client: Client, val ttl: Duration, val flag: Int)
   extends Store[String, ChannelBuffer]
   with WithPutTtl[String, ChannelBuffer, MemcacheStore]
 {

--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
@@ -77,7 +77,7 @@ class MergeableMemcacheStore[K, V](underlying: MemcacheStore, maxRetries: Int)(k
               inj.invert(cbValue) match {
                 case Success(v) => // attempt cas
                   val resV = semigroup.plus(v, kv._2)
-                  underlying.client.cas(key, 0, underlying.ttl.fromNow, inj.apply(resV), casunique).flatMap { success =>
+                  underlying.client.cas(key, underlying.flag, underlying.ttl.fromNow, inj.apply(resV), casunique).flatMap { success =>
                     success.booleanValue match {
                       case true => Future.value(Some(v))
                       case false => doMerge(kv, currentRetry + 1) // retry

--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
@@ -77,7 +77,7 @@ class MergeableMemcacheStore[K, V](underlying: MemcacheStore, maxRetries: Int)(k
               inj.invert(cbValue) match {
                 case Success(v) => // attempt cas
                   val resV = semigroup.plus(v, kv._2)
-                  underlying.client.cas(key, inj.apply(resV), casunique).flatMap { success =>
+                  underlying.client.cas(key, 0, underlying.ttl.fromNow, inj.apply(resV), casunique).flatMap { success =>
                     success.booleanValue match {
                       case true => Future.value(Some(v))
                       case false => doMerge(kv, currentRetry + 1) // retry
@@ -87,7 +87,7 @@ class MergeableMemcacheStore[K, V](underlying: MemcacheStore, maxRetries: Int)(k
               }
             // no pre-existing value, try to 'add' it
             case None =>
-              underlying.client.add(key, inj.apply(kv._2)).flatMap { success =>
+              underlying.client.add(key, 0, underlying.ttl.fromNow, inj.apply(kv._2)).flatMap { success =>
                 success.booleanValue match {
                   case true => Future.None
                   case false => doMerge(kv, currentRetry + 1) // retry, next retry should call cas

--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MergeableMemcacheStore.scala
@@ -87,7 +87,7 @@ class MergeableMemcacheStore[K, V](underlying: MemcacheStore, maxRetries: Int)(k
               }
             // no pre-existing value, try to 'add' it
             case None =>
-              underlying.client.add(key, 0, underlying.ttl.fromNow, inj.apply(kv._2)).flatMap { success =>
+              underlying.client.add(key, underlying.flag, underlying.ttl.fromNow, inj.apply(kv._2)).flatMap { success =>
                 success.booleanValue match {
                   case true => Future.None
                   case false => doMerge(kv, currentRetry + 1) // retry, next retry should call cas


### PR DESCRIPTION
MergeableMemcacheStore was not passing the right TTL setting, and thus was using the default of Time.epoch which never expires the item.

cc @danielhfrank