### PR TITLE
Remove dependency on finagle-http

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -295,7 +295,8 @@ object StorehausBuild extends Build {
 
   lazy val storehausHttp = module("http").settings(
     libraryDependencies ++= Seq(
-      "com.twitter" %% "finagle-http" % finagleVersion,
+      "com.twitter" %% "finagle-httpx" % finagleVersion,
+      "com.twitter" %% "finagle-httpx-compat" % finagleVersion,
       "com.twitter" %% "bijection-netty" % bijectionVersion
     )
   ).dependsOn(storehausCore)

--- a/storehaus-http/src/main/scala/com/twitter/storehaus/http/HttpStore.scala
+++ b/storehaus-http/src/main/scala/com/twitter/storehaus/http/HttpStore.scala
@@ -22,7 +22,8 @@ import org.jboss.netty.handler.codec.http.{ HttpRequest, HttpResponse, DefaultHt
 import com.twitter.util.Future
 import com.twitter.bijection.StringCodec
 import com.twitter.bijection.netty.ChannelBufferBijection
-import com.twitter.finagle.{ Service, Http }
+import com.twitter.finagle.{ Service, Httpx }
+import com.twitter.finagle.httpx.compat.NettyClientAdaptor
 import com.twitter.storehaus.{ Store, ConvertedStore }
 
 object HttpException {
@@ -33,7 +34,7 @@ object HttpException {
 case class HttpException(code: Int, reasonPhrase: String, content: String) extends Exception(reasonPhrase + Option(content).map("\n" + _ ).getOrElse(""))
 
 object HttpStore {
-  def apply(dest: String): HttpStore = new HttpStore(Http.newService(dest))
+  def apply(dest: String): HttpStore = new HttpStore(NettyClientAdaptor andThen Httpx.newService(dest))
 }
 
 class HttpStore(val client: Service[HttpRequest, HttpResponse]) extends Store[String, ChannelBuffer] {
@@ -73,7 +74,7 @@ class HttpStore(val client: Service[HttpRequest, HttpResponse]) extends Store[St
 }
 
 object HttpStringStore {
-  def apply(dest: String): HttpStringStore = new HttpStringStore(Http.newService(dest))
+  def apply(dest: String): HttpStringStore = new HttpStringStore(NettyClientAdaptor andThen Httpx.newService(dest))
 }
 
 class HttpStringStore(val client: Service[HttpRequest, HttpResponse])


### PR DESCRIPTION
Finagle is deprecating the http module in favor of httpx (a similar
module but without leaking underlying implementation i.e. Netty types).

This patch doesn't remove Netty but preserves storehaus's
Netty-dependent API while removing the finagle-http dependency.
(Storehaus can choose to deprecate the Netty API and adopt the
finagle-httpx interface at its own pace.)