### PR TITLE
Fix for issue 287

### DIFF
--- a/storehaus-core/src/main/scala/com/twitter/storehaus/FutureOps.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/FutureOps.scala
@@ -85,12 +85,10 @@ object FutureOps {
     if (futures.isEmpty) {
       Future.exception(new RuntimeException("Empty iterator in FutureOps.find"))
     } else {
-      val hd = futures.head
-      hd.filter(pred).rescue {
+      futures.head.filter(pred).rescue {
         case _: Throwable =>
-          val tl = futures.tail
-          if (tl.isEmpty) hd
-          else find(tl)(pred)
+          if (futures.tail.isEmpty) futures.head
+          else find(futures.tail)(pred)
       }
     }
   }

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/SearchingReadableStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/SearchingReadableStoreProperties.scala
@@ -36,7 +36,7 @@ object SearchingReadableStoreProperties extends Properties("SearchingReadableSto
     }
 
   /**
-   * Creates a Readable Store that delegates to underlying store and
+   * Creates a ReadableStore that delegates to underlying store and
    * records accesses.
    */
   def accessRecordingStore[K, V](underlying: ReadableStore[K, V]) = new ReadableStore[K, V] {


### PR DESCRIPTION
The root cause is that pattern match on a stream evaluates both head and
tail. So in:
def findT(pred: T => Boolean): Future[T] =
futures match {
  case Stream.Empty => Future.exception(new RuntimeException("Empty iterator in FutureOps.find"))
  case last #:: Stream.Empty => last
  case next #:: rest => next.filter(pred).rescue { case _: Throwable => find(rest)(pred) }
}

when the second case is hit i.e. " case last #:: Stream.Empty => last"
it evaluates the tail, resulting in a call to the second store.

Fixed by eliminating the use of pattern match.
