### PR TITLE
Fix the next version. The convention is to call it SNAPSHOT.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15.0"
+version in ThisBuild := "0.15.0-SNAPSHOT"


### PR DESCRIPTION
While doing the release I didn't realize that the convention is to call the next version a SNAPSHOT. Fixing that here.
