### PR TITLE
wrap Cache instead of Map in LRU, TTL, and LIRS caches

### DIFF
--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/Cache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/Cache.scala
@@ -30,14 +30,14 @@ object Cache {
   def fromMap[K, V](m: Map[K, V]) = MapCache(m)
 
   /* Returns an LRUCache configured with the supplied maxSize. */
-  def lru[K, V](maxSize: Long) = LRUCache(maxSize, Map.empty[K, (Long, V)])
+  def lru[K, V](maxSize: Long) = LRUCache(maxSize, MapCache(Map.empty[K, (Long, V)]))
 
   /* Returns an immutable TTLCache configured with the supplied ttl in
    * milliseconds. */
   @deprecated("Use com.twitter.storehaus.cache.Cache#ttl", "0.6.1")
-  def ttl[K, V](ttlInMillis: Long) = TTLCache(Duration.fromMilliseconds(ttlInMillis), Map.empty[K, (Long, V)])
+  def ttl[K, V](ttlInMillis: Long) = TTLCache(Duration.fromMilliseconds(ttlInMillis), MapCache(Map.empty[K, (Long, V)]))
 
-  def ttl[K, V](ttl: Duration) = TTLCache(ttl, Map.empty[K, (Long, V)])
+  def ttl[K, V](ttl: Duration) = TTLCache(ttl, MapCache(Map.empty[K, (Long, V)]))
 
   def toMutable[K, V](cache: Cache[K, V])(exhaustFn: Set[K] => Unit): MutableCache[K, V] =
     new MutableFromImmutableCache(cache)(exhaustFn)

--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/MutableTTLCache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/MutableTTLCache.scala
@@ -20,13 +20,13 @@ import java.util.{ LinkedHashMap => JLinkedHashMap, Map => JMap }
 import com.twitter.util.Duration
 
 object MutableTTLCache {
-  def apply[K, V](ttl: Duration, capacity: Int) = {
+  def apply[K, V](ttl: Duration, capacity: Int, clock: () => Long = () => System.currentTimeMillis) = {
     val backingCache = JMapCache[K, (Long, V)](
       new JLinkedHashMap[K, (Long, V)](capacity + 1, 0.75f) {
         override protected def removeEldestEntry(eldest: JMap.Entry[K, (Long, V)]) =
           super.size > capacity
       })
-    new MutableTTLCache(ttl, backingCache)(() => System.currentTimeMillis)
+    new MutableTTLCache(ttl, backingCache)(clock)
   }
 }
 

--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/TTLCache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/TTLCache.scala
@@ -34,11 +34,11 @@ import com.twitter.util.Duration
  */
 
 object TTLCache {
-  def apply[K, V](ttl: Duration, backingMap: Map[K, (Long, V)] = Map.empty[K, (Long, V)]) =
-    new TTLCache(ttl, backingMap)(() => System.currentTimeMillis)
+  def apply[K, V](ttl: Duration, backingCache: Cache[K, (Long, V)] = MapCache(Map.empty[K, (Long, V)]), clock: () => Long = () => System.currentTimeMillis) =
+    new TTLCache(ttl, backingCache)(clock)
 }
 
-class TTLCache[K, V](val ttl: Duration, cache: Map[K, (Long, V)])(val clock: () => Long) extends Cache[K, (Long, V)] {
+class TTLCache[K, V](val ttl: Duration, cache: Cache[K, (Long, V)])(val clock: () => Long) extends Cache[K, (Long, V)] {
   override def get(k: K) = cache.get(k)
   override def contains(k: K) = cache.contains(k)
   override def hit(k: K) = this


### PR DESCRIPTION
Addresses #96. Also lets the current time getter be passed via the convenience constructor for the TTL caches. For testing, I find it helpful to have explicit control over the impure time getter function, rather than having it be internal. It wouldn't be a big deal to just use the regular constructor for `TTLCache`, but for `MutableTTLCache`, the convenience constructor does a lot more.
