### PR TITLE
Fix for incorrect error message in MergeableStoreViaGetPut

### DIFF
--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
@@ -18,7 +18,7 @@ package com.twitter.storehaus.algebra
 
 import com.twitter.algebird.{Monoid, Semigroup}
 import com.twitter.bijection.ImplicitBijection
-import com.twitter.storehaus.{CollectionOps, FutureCollector, FutureOps, MissingValueException, Store}
+import com.twitter.storehaus.{FutureCollector, FutureOps, MissingValueException, Store}
 import com.twitter.util.{Future, Promise, Return, Throw, Try}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
 import scala.language.implicitConversions

--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
@@ -89,6 +89,7 @@ object MergeableStore {
       val countdown = new AtomicInteger(fsSize)
       val pResult = new Promise[(Map[K, V], Map[K, Throwable])]
 
+      @inline
       def collectResults() = {
         if (countdown.decrementAndGet() == 0) {
           var successes = Map.empty[K, V]

--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
@@ -18,7 +18,7 @@ package com.twitter.storehaus.algebra
 
 import com.twitter.algebird.{Monoid, Semigroup}
 import com.twitter.bijection.ImplicitBijection
-import com.twitter.storehaus.{CollectionOps, FutureCollector, FutureOps, MissingValueException, Store}
+import com.twitter.storehaus.{FutureCollector, FutureOps, MissingValueException, Store}
 import com.twitter.util.{Future, Promise, Return, Throw}
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
 import scala.language.implicitConversions

--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
@@ -31,6 +31,7 @@ object MergeableStore {
   implicit def enrich[K, V](store: MergeableStore[K, V]): EnrichedMergeableStore[K, V] =
     new EnrichedMergeableStore(store)
 
+  // todo(pankajg) After merging latest algebird replace this with Semigroup.maybePlus
   private[this] def addOpt[V](init: Option[V], inc: V)(implicit sg: Semigroup[V]): Option[V] = init match {
     case Some(i) => Some(sg.plus(i, inc))
     case None => Some(inc)

--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStore.scala
@@ -37,6 +37,16 @@ object MergeableStore {
   }
 
   /**
+   * Use the newer function with less params below. This function just
+   * calls that ignoring missingfn and collect.
+   */
+  @deprecated
+  def multiMergeFromMultiSet[K, V](store: Store[K, V], kvs: Map[K, V],
+    missingfn: (K) => Future[Option[V]] = FutureOps.missingValueFor _)
+    (implicit collect: FutureCollector, sg: Semigroup[V]): Map[K, Future[Option[V]]] =
+    multiMergeFromMultiSet(store, kvs)
+
+  /**
   * Implements multiMerge functionality in terms of an underlying
   * store's multiGet and multiSet.
   */
@@ -79,7 +89,7 @@ object MergeableStore {
     /**
      *  A bit complex but it saves us an intermediate map creation. Here's the logic:
      *  If key is present in put results map successful ones to old value, failures remain.
-     *  If not in put results then map to corresponding failure in getFailures.
+     *  If not in put results then map to corresponding get failure.
      *  Ultimately we will have successful puts(mapped to old value), put failures and get failures.
      */
     @inline

--- a/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStoreViaGetPut.scala
+++ b/storehaus-algebra/src/main/scala/com/twitter/storehaus/algebra/MergeableStoreViaGetPut.scala
@@ -55,6 +55,6 @@ class MergeableStoreViaGetPut[-K, V: Semigroup](
     store.multiPut(kvs)
 
   override def multiMerge[K1 <: K](kvs: Map[K1, V]): Map[K1, Future[Option[V]]] = {
-    MergeableStore.multiMergeFromMultiSet(this, kvs)(fc, semigroup)
+    MergeableStore.multiMergeFromMultiSet(this, kvs)(semigroup)
   }
 }

--- a/storehaus-algebra/src/test/scala/com/twitter/storehaus/algebra/MergeableStoreProperties.scala
+++ b/storehaus-algebra/src/test/scala/com/twitter/storehaus/algebra/MergeableStoreProperties.scala
@@ -227,7 +227,7 @@ object MergeableStoreProperties extends Properties("MergeableStore") {
     forAll { ins: Map[Int, Int] =>
       val fSleep = Future.sleep(Duration.fromMilliseconds(10))
       val futures = ins.mapValues(x => fSleep.map(_ => x))
-      val fResult = MergeableStore.collectWithFailures(futures)
+      val fResult = MergeableStore.collectWithFailures(futures.iterator, futures.size)
       val (ss, _) = Await.result(fResult)
       ss.size == futures.size && ss.toSeq.sorted == ins.toSeq.sorted
     }
@@ -238,7 +238,7 @@ object MergeableStoreProperties extends Properties("MergeableStore") {
       val throwable = new RuntimeException
       val fSleep = Future.sleep(Duration.fromMilliseconds(10))
       val futures = ins.mapValues(_ => fSleep before Future.exception(throwable))
-      val fResult = MergeableStore.collectWithFailures(futures)
+      val fResult = MergeableStore.collectWithFailures(futures.iterator, futures.size)
       val (_, fails) = Await.result(fResult)
       fails.size == futures.size && fails.map(_._2).forall(_ == throwable)
     }

--- a/storehaus-algebra/src/test/scala/com/twitter/storehaus/algebra/MergeableStoreProperties.scala
+++ b/storehaus-algebra/src/test/scala/com/twitter/storehaus/algebra/MergeableStoreProperties.scala
@@ -185,26 +185,74 @@ object MergeableStoreProperties extends Properties("MergeableStore") {
     }
   }
 
-  // Drops all puts, returns the specified result on get.
-  class MockStore[K, V](getResult: Future[Option[V]]) extends Store[K, V] {
-    override def get(k: K): Future[Option[V]] = getResult
-    override def put(kv: (K, Option[V])): Future[Unit] = Future.Unit
+  // Returns the specified get/put results
+  def mockGetPutStore[K, V](getResult: Future[Option[V]], putResult: Future[Unit] = Future.Unit): Store[K, V] =
+    new MockGetPutByKeyStore[K, V](_ => getResult, _ => putResult)
+
+  def mockGetPutByKeyStore[K, V](getResult: K => Future[Option[V]], putResult: K => Future[Unit]): Store[K, V] =
+    new MockGetPutByKeyStore[K, V](getResult, putResult)
+
+  // Returns the specified get/put results
+  class MockGetPutByKeyStore[K, V](getResult: K => Future[Option[V]], putResult: K => Future[Unit]) extends Store[K, V] {
+    override def get(k: K): Future[Option[V]] = getResult(k)
+    override def put(kv: (K, Option[V])): Future[Unit] = putResult(kv._1)
   }
 
   property("multiMergeFromMultiSet handles store failures correctly") = {
     val intSg = implicitly[Semigroup[Int]]
     val storeException = new RuntimeException("Failure in store")
     val storeExceptionFut = Future.exception[Option[Int]](storeException)
-    val missingException = new RuntimeException("Missing value")
-    val missingExceptionFut = Future.exception[Option[Int]](missingException)
-    val missingfn: Int => Future[Option[Int]] = _ => missingExceptionFut
 
     forAll { (ins: Map[Int, Int]) =>
       val result = MergeableStore.multiMergeFromMultiSet(
-        new MockStore[Int, Int](storeExceptionFut), ins)(intSg)
+        mockGetPutStore[Int, Int](storeExceptionFut), ins)(intSg)
       result.values.forall { v =>
         Await.result(v.liftToTry).throwable == storeException
       }
+    }
+  }
+
+  property("multiMergeFromMultiSet handles put failures correctly") = {
+    val intSg = implicitly[Semigroup[Int]]
+    val storeException = new RuntimeException("Failure in store")
+    val getResultFut: Future[Option[Int]] = Future.value(None)
+    val putExceptionFut = Future.exception[Unit](storeException)
+
+    forAll { (ins: Map[Int, Int]) =>
+      val result = MergeableStore.multiMergeFromMultiSet(
+        mockGetPutStore[Int, Int](getResultFut, putExceptionFut), ins)(intSg)
+      result.values.forall { v =>
+        Await.result(v.liftToTry).throwable == storeException
+      }
+    }
+  }
+
+  def posMod(n: Int, d: Int): Int = ((n % d) + d) %d
+
+  property("multiMergeFromMultiSet handles partial failures correctly") = {
+    val intSg = implicitly[Semigroup[Int]]
+    val storeException = new RuntimeException("Failure in store")
+    val getExceptionFut = Future.exception[Option[Int]](storeException)
+    val putExceptionFut = Future.exception[Unit](storeException)
+
+    // Strategy: All keys divisible by 3 fail on get, with remainder 1 fail on put, rest should succeed
+    def part1(k: Int): Boolean = posMod(k, 3) == 0
+    def part2(k: Int): Boolean = posMod(k, 3) == 1
+    def part3(k: Int): Boolean = posMod(k, 3) == 2
+
+    val getResultFut: Int => Future[Option[Int]] = k => if (part1(k)) getExceptionFut else Future.value(Some(k))
+    val putResultFut: Int => Future[Unit] = k => if (part2(k)) putExceptionFut else Future.Unit
+
+    forAll { (ins: Map[Int, Int]) =>
+      val result = MergeableStore.multiMergeFromMultiSet(
+        mockGetPutByKeyStore[Int, Int](getResultFut, putResultFut), ins)(intSg)
+      val predSuccess = result.filterKeys(part3(_)).forall { case (k, v) =>
+        Await.result(v).get == k
+      }
+      val predFail = result.filterKeys(!part3(_)).values.forall { v =>
+        Await.result(v.liftToTry).throwable == storeException
+      }
+      predFail && predSuccess
     }
   }
 
@@ -241,6 +289,21 @@ object MergeableStoreProperties extends Properties("MergeableStore") {
       val fResult = MergeableStore.collectWithFailures(futures.iterator, futures.size)
       val (_, fails) = Await.result(fResult)
       fails.size == futures.size && fails.map(_._2).forall(_ == throwable)
+    }
+  }
+
+  property("collectWithFailures should collect mix of successes and failures correctly") = {
+    forAll { ins: Map[Int, Int] =>
+      val throwable = new RuntimeException
+      val fSleep = Future.sleep(Duration.fromMilliseconds(10))
+      val successes = ins.filterKeys(_ % 2 == 0).mapValues(x => fSleep.map(_ => x))
+      val failures = ins.filterKeys(_ %2 != 0).mapValues(_ => fSleep before Future.exception(throwable))
+      val futures = successes ++ failures
+      val fResult = MergeableStore.collectWithFailures(futures.iterator, futures.size)
+      val (ss, fails) = Await.result(fResult)
+      fails.size == failures.size && fails.map(_._2).forall(_ == throwable) &&
+        (fails.size + ss.size) == ins.size
+
     }
   }
 }

--- a/storehaus-algebra/src/test/scala/com/twitter/storehaus/algebra/MergeableStoreProperties.scala
+++ b/storehaus-algebra/src/test/scala/com/twitter/storehaus/algebra/MergeableStoreProperties.scala
@@ -227,8 +227,8 @@ object MergeableStoreProperties extends Properties("MergeableStore") {
     forAll { ins: Map[Int, Int] =>
       val fSleep = Future.sleep(Duration.fromMilliseconds(10))
       val futures = ins.mapValues(x => fSleep.map(_ => x))
-      val (fSuccess, _) = MergeableStore.collectWithFailures(futures)
-      val ss = Await.result(fSuccess)
+      val fResult = MergeableStore.collectWithFailures(futures)
+      val (ss, _) = Await.result(fResult)
       ss.size == futures.size && ss.toSeq.sorted == ins.toSeq.sorted
     }
   }
@@ -238,8 +238,8 @@ object MergeableStoreProperties extends Properties("MergeableStore") {
       val throwable = new RuntimeException
       val fSleep = Future.sleep(Duration.fromMilliseconds(10))
       val futures = ins.mapValues(_ => fSleep before Future.exception(throwable))
-      val (_, fFailures) = MergeableStore.collectWithFailures(futures)
-      val fails = Await.result(fFailures)
+      val fResult = MergeableStore.collectWithFailures(futures)
+      val (_, fails) = Await.result(fResult)
       fails.size == futures.size && fails.map(_._2).forall(_ == throwable)
     }
   }


### PR DESCRIPTION
MergeableStoreViaGetPut has a bug when using FutureCollector.bestEffort. When any of the multiget requests fail they are ignored (which is correct) and afterwards all the dropped keys are mapped using missingFn which typically results in mapping to MissingValueException. The end result is that the root cause of failures of get requests is hidden and replaced with these MissingValueExceptions. This confuses users, making them think that the underlying store (such as Memcache) has lost data, whereas many times it's just timeouts. We should preserve the original exception for the get request failure, and this is what this PR is about.

But to achieve this behavior FutureCollector interface isn't sufficient, we need to get the successful results as well as the unsuccessful ones. Plus generality of using FutureCollector doesn't seem useful here. There are only two FutureCollectors currently, bestEffort and default. The default FutureCollector fails the entire multiget request if even one of the requests fails. I can't imagine any reasonable case where we'd want that behavior. So it seems best to me to remove the option of FutureCollector completely as I have proposed here. This would ultimately chain up to removing FutureCollector from MergeableStore.fromStore.

Before undertaking that api breaking change I wanted to get some feedback. Is there a valid use case for FutureCollector.default? If so any recommendations on how to organize the change. I have some ideas on how to achieve this if needed but none clean. e.g. we could fork requirements into separate functions at some level.

If the current PR looks to be on the right track I plan to remove FutureCollector for this code path and add tests for collectWithFailure.