### PR TITLE
Occupancy for Cache trait implementation classes

### DIFF
--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/Cache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/Cache.scala
@@ -83,6 +83,9 @@ trait Cache[K, V] {
   /** Returns an empty version of this specific cache implementation. */
   def empty: Cache[K, V]
 
+  /** Returns the amount of elements in the cache (i.e. its occupancy)*/
+  def occupancy: Int
+
   /**
    * Returns true if the cache contains a value for the supplied key,
    * false otherwise.

--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/LIRSCache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/LIRSCache.scala
@@ -166,6 +166,8 @@ class LIRSCache[K, V](lirsStacks: LIRSStacks[K], backingMap: Map[K, V]) extends 
 
   def empty: Cache[K, V] = new LIRSCache(lirsStacks.empty, backingMap.empty)
 
+  def occupancy: Int = backingMap.size
+
   override def toString: String = {
     val pairStrings = iterator.map { case (k, v) => k + " -> " + v }
     "LIRSCache(" + pairStrings.toList.mkString(", ") + ")"

--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/LRUCache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/LRUCache.scala
@@ -89,6 +89,7 @@ class LRUCache[K, V](maxSize: Long, idx: Long, map: Map[K, (Long, V)], ord: Sort
   }
 
   override def empty: LRUCache[K, V] = new LRUCache(maxSize, 0, map.empty, ord.empty)
+  override def occupancy: Int = map.size
   override def iterator: Iterator[(K, V)] = map.iterator.map { case (k, (_, v)) => k -> v }
   override def toMap: Map[K, V] = map.mapValues { _._2 }
 }

--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/MapCache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/MapCache.scala
@@ -40,5 +40,6 @@ class MapCache[K, V](m: Map[K, V]) extends Cache[K, V] {
   override def toMap: Map[K, V] = m
   override def iterator: Iterator[(K, V)] = m.iterator
   override def empty: MapCache[K, V] = new MapCache(Map.empty[K, V])
+  override def occupancy: Int = m.size
   override def seed(newPairs: Map[K, V]): MapCache[K, V] = new MapCache(newPairs)
 }

--- a/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/TTLCache.scala
+++ b/storehaus-cache/src/main/scala/com/twitter/storehaus/cache/TTLCache.scala
@@ -55,6 +55,7 @@ class TTLCache[K, V](val ttl: Duration, cache: Map[K, (Long, V)])(val clock: () 
     }.getOrElse((None, this))
 
   override def empty: TTLCache[K, V] = new TTLCache(ttl, cache.empty)(clock)
+  override def occupancy: Int = cache.size
   override def iterator: Iterator[(K, (Long, V))] = cache.iterator
   override def toMap: Map[K, (Long, V)] = cache
 


### PR DESCRIPTION
Added a function to be able to access the cache occupancy (amount of elements) of it