### PR TITLE
Upgrate to Finagle 6.43.0 and preparing the path for Scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 *.jar
 *~
+.DS_Store
 
 #sbt
 /project/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,18 @@ matrix:
       script: umask 0022 && ./sbt ++$TRAVIS_SCALA_VERSION clean test mimaReportBinaryIssues
 
     - scala: 2.11.8
+      jdk: oraclejdk8
       script: umask 0022 && ./sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport mimaReportBinaryIssues
       after_success:
         - bash <(curl -s https://codecov.io/bash)
 before_script:
+  - sleep 15 # https://docs.travis-ci.com/user/database-setup/#MongoDB
+  - mongo mydb_test --eval 'db.addUser("travis", "test");'
   - mysql -u root -e "create database storehaus_test;"
   - mysql -u root -e "create user 'storehaususer'@'localhost' identified by 'test1234';"
   - mysql -u root -e "grant all on storehaus_test.* to 'storehaususer'@'localhost';"
 services:
+  - mysql
   - redis-server
   - memcache
   - mongodb

--- a/build.sbt
+++ b/build.sbt
@@ -56,17 +56,39 @@ val ignoredABIProblems = {
       ".futurePool"),
     exclude[MissingMethodProblem]("com.twitter.storehaus.asynchbase.AsyncHBaseStore.futurePool"),
     exclude[MissingMethodProblem]("com.twitter.storehaus.ReadThroughStore.mutex"),
-    exclude[MissingClassProblem]("com.twitter.storehaus.kafka.JavaFutureToTwitterFutureConverter$Closed$"),
-    exclude[DirectMissingMethodProblem]("com.twitter.storehaus.kafka.KafkaStore.<init>$default$3")
+    exclude[MissingClassProblem]("com.twitter.storehaus.kafka" +
+      ".JavaFutureToTwitterFutureConverter$Closed$"),
+    exclude[DirectMissingMethodProblem]("com.twitter.storehaus.kafka.KafkaStore.<init>$default$3"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.http.HttpException.apply"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.apply"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.MySqlLongStore.apply"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.ValueMapper" +
+      ".toChannelBuffer"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.ValueMapper.toLong"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.ValueMapper.toString"),
+    exclude[IncompatibleResultTypeProblem]("com.twitter.storehaus.mysql.MySqlValue.v"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.MySqlValue.this"),
+    exclude[IncompatibleResultTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.client"),
+    exclude[IncompatibleResultTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.deleteStmt"),
+    exclude[IncompatibleResultTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.updateStmt"),
+    exclude[IncompatibleResultTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.selectStmt"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.this"),
+    exclude[IncompatibleResultTypeProblem]("com.twitter.storehaus.mysql.MySqlStore.insertStmt")
   )
 }
 
 val sharedSettings = extraSettings ++ ciSettings ++ Seq(
   organization := "com.twitter",
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.6", "2.11.8"),
-  javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-  javacOptions in doc := Seq("-source", "1.6"),
+  crossScalaVersions := Seq("2.10.6", scalaVersion.value),
+  javacOptions ++= (
+    if (scalaVersion.value.startsWith("2.10.")) Seq("-source", "1.6", "-target", "1.6")
+    else Seq("-source", "1.8", "-target", "1.8")
+  ),
+  javacOptions in doc := (
+    if (scalaVersion.value.startsWith("2.10.")) Seq("-source", "1.6")
+    else Seq("-source", "1.8")
+  ),
   libraryDependencies += "org.scalatest" %% "scalatest" % scalatestVersion % "test",
   resolvers ++= Seq(
     Opts.resolver.sonatypeSnapshots,

--- a/build.sbt
+++ b/build.sbt
@@ -226,11 +226,7 @@ lazy val storehausMemcache = module("memcache").settings(
     "com.twitter" %% "algebird-core" % algebirdVersion,
     "com.twitter" %% "bijection-core" % bijectionVersion,
     "com.twitter" %% "bijection-netty" % bijectionVersion,
-    "com.twitter" %% "finagle-memcached" % finagleVersion(scalaVersion.value) excludeAll(
-      // we don't use this and its not on maven central.
-      ExclusionRule("com.twitter.common.zookeeper"),
-      ExclusionRule("com.twitter.common")
-      )
+    "com.twitter" %% "finagle-memcached" % finagleVersion(scalaVersion.value)
   )
 ).dependsOn(storehausAlgebra % "test->test;compile->compile")
 

--- a/build.sbt
+++ b/build.sbt
@@ -63,10 +63,10 @@ val ignoredABIProblems = {
 
 val sharedSettings = extraSettings ++ ciSettings ++ Seq(
   organization := "com.twitter",
-  scalaVersion := "2.11.7",
-  crossScalaVersions := Seq("2.10.6", "2.11.7"),
-  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-  javacOptions in doc := Seq("-source", "1.8"),
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.10.6", "2.11.8"),
+  javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
+  javacOptions in doc := Seq("-source", "1.6"),
   libraryDependencies += "org.scalatest" %% "scalatest" % scalatestVersion % "test",
   resolvers ++= Seq(
     Opts.resolver.sonatypeSnapshots,

--- a/build.sbt
+++ b/build.sbt
@@ -65,8 +65,8 @@ val sharedSettings = extraSettings ++ ciSettings ++ Seq(
   organization := "com.twitter",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.10.6", "2.11.7"),
-  javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
-  javacOptions in doc := Seq("-source", "1.6"),
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+  javacOptions in doc := Seq("-source", "1.8"),
   libraryDependencies += "org.scalatest" %% "scalatest" % scalatestVersion % "test",
   resolvers ++= Seq(
     Opts.resolver.sonatypeSnapshots,

--- a/storehaus-http/src/main/scala-2.10/com/twitter/storehaus/http/compat/HttpCompatClient.scala
+++ b/storehaus-http/src/main/scala-2.10/com/twitter/storehaus/http/compat/HttpCompatClient.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.http.compat
+
+import org.jboss.netty.handler.codec.http.{ DefaultHttpRequest => NettyDefaultHttpRequest}
+import org.jboss.netty.handler.codec.http.{ DefaultHttpResponse => NettyDefaultHttpResponse}
+import org.jboss.netty.handler.codec.http.{ HttpHeaders => NettyHttpHeaders }
+import org.jboss.netty.handler.codec.http.{ HttpRequest => NettyHttpRequest }
+import org.jboss.netty.handler.codec.http.{ HttpResponse => NettyHttpResponse }
+import org.jboss.netty.handler.codec.http.{ HttpVersion => NettyHttpVersion }
+import org.jboss.netty.handler.codec.http.{ HttpMethod => NettyHttpMethod }
+import org.jboss.netty.handler.codec.http.{ HttpResponseStatus => NettyHttpResponseStatus }
+import org.jboss.netty.buffer.{ ChannelBuffer => NettyChannelBuffer }
+import java.nio.charset.Charset
+
+object HttpCompatClient {
+
+  val OK = NettyHttpResponseStatus.OK
+
+  val CREATED = NettyHttpResponseStatus.CREATED
+
+  val NOT_FOUND = NettyHttpResponseStatus.NOT_FOUND
+
+  val NO_CONTENT = NettyHttpResponseStatus.NO_CONTENT
+
+  val METHOD_NOT_ALLOWED = NettyHttpResponseStatus.METHOD_NOT_ALLOWED
+
+  val CONTENT_LENGTH = NettyHttpHeaders.Names.CONTENT_LENGTH
+
+  val GET = NettyHttpMethod.GET
+
+  val PUT = NettyHttpMethod.PUT
+
+  val DELETE = NettyHttpMethod.DELETE
+
+  def getStatus(rep: NettyHttpResponse) =
+    rep.getStatus
+
+  def getStatusCode(rep: NettyHttpResponse) =
+    rep.getStatus.getCode
+
+  def getStatusReasonPhrase(rep: NettyHttpResponse) =
+    rep.getStatus.getReasonPhrase
+
+  def getContent(rep: NettyHttpResponse) =
+    rep.getContent
+
+  def getContent(req: NettyHttpRequest) =
+    req.getContent
+
+  def setContent(req: NettyHttpRequest, cb: NettyChannelBuffer) =
+    req.setContent(cb)
+
+  def setContent(rep: NettyHttpResponse, cb: NettyChannelBuffer) =
+    rep.setContent(cb)
+
+  def getContentString(rep: NettyHttpResponse) =
+    rep.getContent.toString(Charset.forName("UTF-8"))
+
+  def getContentString(req: NettyHttpRequest) =
+    req.getContent.toString(Charset.forName("UTF-8"))
+
+  def getContentReadableBytes(req: NettyHttpRequest) =
+    getContent(req).readableBytes
+
+  def getMethod(req: NettyHttpRequest) =
+    req.getMethod
+
+  def getUri(req: NettyHttpRequest) =
+    req.getUri
+
+  def getDefaultHttpResponseForRequest(req: NettyHttpRequest, status: NettyHttpResponseStatus) =
+    new NettyDefaultHttpResponse(req.getProtocolVersion, status)
+
+  def getDefaultHttpGetRequestForUrl(url: String) =
+    new NettyDefaultHttpRequest(NettyHttpVersion.HTTP_1_1, NettyHttpMethod.GET, url)
+
+  def getDefaultHttpPutRequestForUrl(url: String) =
+    new NettyDefaultHttpRequest(NettyHttpVersion.HTTP_1_1, NettyHttpMethod.PUT, url)
+
+  def getDefaultHttpDeleteRequestForUrl(url: String) =
+    new NettyDefaultHttpRequest(NettyHttpVersion.HTTP_1_1, NettyHttpMethod.DELETE, url)
+
+  def setHeader(req: NettyHttpRequest, name: String, value: String) =
+    req.headers.set(name, value)
+
+  def setHeader(rep: NettyHttpResponse, name: String, value: String) =
+    rep.headers.set(name, value)
+
+}

--- a/storehaus-http/src/main/scala-2.10/com/twitter/storehaus/http/compat/package.scala
+++ b/storehaus-http/src/main/scala-2.10/com/twitter/storehaus/http/compat/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.http
+
+package object compat {
+
+  type HttpRequest = org.jboss.netty.handler.codec.http.HttpRequest
+
+  type HttpResponse = org.jboss.netty.handler.codec.http.HttpResponse
+
+  val NettyAdaptor = com.twitter.finagle.http.compat.NettyAdaptor
+
+  val NettyClientAdaptor = com.twitter.finagle.http.compat.NettyClientAdaptor
+
+}

--- a/storehaus-http/src/main/scala-2.11/com/twitter/storehaus/http/compat/HttpCompatClient.scala
+++ b/storehaus-http/src/main/scala-2.11/com/twitter/storehaus/http/compat/HttpCompatClient.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.http.compat
+
+import com.twitter.finagle.http.{ Fields, Method, Request, Response, Status }
+import com.twitter.finagle.netty3.{ BufChannelBuffer, ChannelBufferBuf }
+import org.jboss.netty.buffer.ChannelBuffer
+
+object HttpCompatClient {
+
+  val OK = Status.Ok
+
+  val NOT_FOUND = Status.NotFound
+
+  val CREATED = Status.Created
+
+  val NO_CONTENT = Status.NoContent
+
+  val METHOD_NOT_ALLOWED = Status.MethodNotAllowed
+
+  val CONTENT_LENGTH = Fields.ContentLength
+
+  val GET = Method.Get
+
+  val PUT = Method.Put
+
+  val DELETE = Method.Delete
+
+  def getStatus(rep: Response) =
+    rep.status
+
+  def getStatusCode(rep: Response) =
+    rep.statusCode
+
+  def getStatusReasonPhrase(rep: Response) =
+    rep.status.reason
+
+  def getContent(rep: Response) =
+    BufChannelBuffer(rep.content)
+
+  def getContent(req: Request) =
+    BufChannelBuffer(req.content)
+
+  def setContent(req: Request, cb: ChannelBuffer) =
+    req.content = new ChannelBufferBuf(cb)
+
+  def setContent(rep: Response, cb: ChannelBuffer) =
+    rep.content = new ChannelBufferBuf(cb)
+
+  def getContentString(rep: Response) =
+    rep.contentString
+
+  def getContentString(req: Request) =
+    req.contentString
+
+  def getContentReadableBytes(req: Request) =
+    getContent(req).readableBytes
+
+  def getMethod(req: Request) =
+    req.method
+
+  def getUri(req: Request) =
+    req.uri
+
+  def getDefaultHttpResponseForRequest(req: Request, status: Status) = {
+    val res = Response(req)
+    res.status = status
+    res
+  }
+
+  def getDefaultHttpGetRequestForUrl(url: String) =
+    Request(url)
+
+  def getDefaultHttpPutRequestForUrl(url: String) =
+    Request(Method.Put, url)
+
+  def getDefaultHttpDeleteRequestForUrl(url: String) =
+    Request(Method.Delete, url)
+
+  def setHeader(req: Request, name: String, value: String) =
+    req.headerMap.set(name, value)
+
+  def setHeader(rep: Response, name: String, value: String) =
+    rep.headerMap.set(name, value)
+
+
+}

--- a/storehaus-http/src/main/scala-2.11/com/twitter/storehaus/http/compat/package.scala
+++ b/storehaus-http/src/main/scala-2.11/com/twitter/storehaus/http/compat/package.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.http
+
+import com.twitter.finagle.http.{ Request, Response }
+import com.twitter.finagle.Filter
+
+package object compat {
+
+  type HttpRequest = Request
+
+  type HttpResponse = Response
+
+  val NettyAdaptor = Filter.identity[Request, Response]
+
+  val NettyClientAdaptor = Filter.identity[Request, Response]
+
+}

--- a/storehaus-memcache/src/main/scala-2.10/com/twitter/storehaus/memcache/compat/MemcacheCompatClient.scala
+++ b/storehaus-memcache/src/main/scala-2.10/com/twitter/storehaus/memcache/compat/MemcacheCompatClient.scala
@@ -1,0 +1,33 @@
+package com.twitter.storehaus.memcache.compat
+
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.memcached.Client
+import com.twitter.finagle.memcached.KetamaClientBuilder
+import com.twitter.finagle.memcached.protocol.text.Memcached
+import com.twitter.util.Duration
+
+object MemcacheCompatClient {
+
+  def defaultClient(
+    name: String,
+    nodeString: String,
+    retries: Int,
+    timeout: Duration,
+    hostConnectionLimit: Int): Client = {
+    val builder = ClientBuilder()
+      .name(name)
+      .retries(retries)
+      .tcpConnectTimeout(timeout)
+      .requestTimeout(timeout)
+      .connectTimeout(timeout)
+      .readerIdleTimeout(timeout)
+      .hostConnectionLimit(hostConnectionLimit)
+      .codec(Memcached())
+
+    KetamaClientBuilder()
+      .clientBuilder(builder)
+      .nodes(nodeString)
+      .build()
+  }
+
+}

--- a/storehaus-memcache/src/main/scala-2.11/com/twitter/storehaus/memcache/compat/MemcacheCompatClient.scala
+++ b/storehaus-memcache/src/main/scala-2.11/com/twitter/storehaus/memcache/compat/MemcacheCompatClient.scala
@@ -1,0 +1,35 @@
+package com.twitter.storehaus.memcache.compat
+
+import com.twitter.finagle.builder.ClientBuilder
+import com.twitter.finagle.memcached.Client
+import com.twitter.finagle.memcached.KetamaClientBuilder
+import com.twitter.finagle.memcached.protocol.text.Memcached
+import com.twitter.util.Duration
+
+object MemcacheCompatClient {
+
+  // FIXME use Stack.Params
+  def defaultClient(
+    name: String,
+    nodeString: String,
+    retries: Int,
+    timeout: Duration,
+    hostConnectionLimit: Int): Client = {
+    val builder = ClientBuilder()
+      .name(name)
+      .retries(retries)
+      .tcpConnectTimeout(timeout)
+      .requestTimeout(timeout)
+      .connectTimeout(timeout)
+      // FIXME use SessionParam.maxIdleTime once migrated to Stack params
+      // .readerIdleTimeout(timeout)
+      .hostConnectionLimit(hostConnectionLimit)
+      .codec(Memcached())
+
+    KetamaClientBuilder()
+      .clientBuilder(builder)
+      .nodes(nodeString)
+      .build()
+  }
+
+}

--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
@@ -20,14 +20,12 @@ import com.twitter.algebird.Semigroup
 import com.twitter.bijection.{ Codec, Injection }
 import com.twitter.bijection.netty.Implicits._
 import com.twitter.conversions.time._
-import com.twitter.finagle.builder.ClientBuilder
-import com.twitter.finagle.memcached.KetamaClientBuilder
-import com.twitter.finagle.memcached.protocol.text.Memcached
 import com.twitter.finagle.netty3.{BufChannelBuffer, ChannelBufferBuf}
 import com.twitter.util.{ Duration, Future, Time }
 import com.twitter.finagle.memcached.Client
 import com.twitter.storehaus.{ FutureOps, Store, WithPutTtl }
 import com.twitter.storehaus.algebra.MergeableStore
+import com.twitter.storehaus.memcache.compat.MemcacheCompatClient
 import org.jboss.netty.buffer.ChannelBuffer
 
 import Store.enrich
@@ -64,20 +62,8 @@ object MemcacheStore {
     retries: Int = DEFAULT_RETRIES,
     timeout: Duration = DEFAULT_TIMEOUT,
     hostConnectionLimit: Int = DEFAULT_CONNECTION_LIMIT): Client = {
-    val builder = ClientBuilder()
-      .name(name)
-      .retries(retries)
-      .tcpConnectTimeout(timeout)
-      .requestTimeout(timeout)
-      .connectTimeout(timeout)
-      .readerIdleTimeout(timeout)
-      .hostConnectionLimit(hostConnectionLimit)
-      .codec(Memcached())
-
-    KetamaClientBuilder()
-      .clientBuilder(builder)
-      .nodes(nodeString)
-      .build()
+    MemcacheCompatClient.defaultClient(name, nodeString, retries,
+      timeout, hostConnectionLimit)
   }
 
   /**

--- a/storehaus-mysql/src/main/scala-2.10/com/twitter/storehaus/mysql/compat/package.scala
+++ b/storehaus-mysql/src/main/scala-2.10/com/twitter/storehaus/mysql/compat/package.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.mysql
+
+package object compat {
+
+  val Mysql = com.twitter.finagle.exp.Mysql
+
+  type Client = com.twitter.finagle.exp.mysql.Client
+
+  type Result = com.twitter.finagle.exp.mysql.Result
+
+  type Parameter = com.twitter.finagle.exp.mysql.Parameter
+
+  val Parameter = com.twitter.finagle.exp.mysql.Parameter
+
+  val EmptyValue = com.twitter.finagle.exp.mysql.EmptyValue
+
+  val IntValue = com.twitter.finagle.exp.mysql.IntValue
+
+  val LongValue = com.twitter.finagle.exp.mysql.LongValue
+
+  val NullValue = com.twitter.finagle.exp.mysql.NullValue
+
+  val RawValue = com.twitter.finagle.exp.mysql.RawValue
+
+  val ShortValue = com.twitter.finagle.exp.mysql.ShortValue
+
+  val StringValue = com.twitter.finagle.exp.mysql.StringValue
+
+  type Value = com.twitter.finagle.exp.mysql.Value
+
+  val Charset = com.twitter.finagle.exp.mysql.Charset
+
+  val Type = com.twitter.finagle.exp.mysql.Type
+
+}

--- a/storehaus-mysql/src/main/scala-2.11/com/twitter/storehaus/mysql/compat/package.scala
+++ b/storehaus-mysql/src/main/scala-2.11/com/twitter/storehaus/mysql/compat/package.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Twitter Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.storehaus.mysql
+
+package object compat {
+
+  val Mysql = com.twitter.finagle.Mysql
+
+  type Client = com.twitter.finagle.mysql.Client
+
+  type Result = com.twitter.finagle.mysql.Result
+
+  type Parameter = com.twitter.finagle.mysql.Parameter
+
+  val Parameter = com.twitter.finagle.mysql.Parameter
+
+  val EmptyValue = com.twitter.finagle.mysql.EmptyValue
+
+  val IntValue = com.twitter.finagle.mysql.IntValue
+
+  val LongValue = com.twitter.finagle.mysql.LongValue
+
+  val NullValue = com.twitter.finagle.mysql.NullValue
+
+  val RawValue = com.twitter.finagle.mysql.RawValue
+
+  val ShortValue = com.twitter.finagle.mysql.ShortValue
+
+  val StringValue = com.twitter.finagle.mysql.StringValue
+
+  type Value = com.twitter.finagle.mysql.Value
+
+  val Charset = com.twitter.finagle.mysql.Charset
+
+  val Type = com.twitter.finagle.mysql.Type
+
+}

--- a/storehaus-mysql/src/main/scala/com/twitter/storehaus/mysql/MySqlLongStore.scala
+++ b/storehaus-mysql/src/main/scala/com/twitter/storehaus/mysql/MySqlLongStore.scala
@@ -18,7 +18,7 @@ package com.twitter.storehaus.mysql
 
 import com.twitter.algebird.Semigroup
 import com.twitter.bijection.Injection
-import com.twitter.finagle.exp.mysql.Client
+import com.twitter.storehaus.mysql.compat.Client
 
 /**
   * @author Ruban Monu

--- a/storehaus-mysql/src/main/scala/com/twitter/storehaus/mysql/MySqlStore.scala
+++ b/storehaus-mysql/src/main/scala/com/twitter/storehaus/mysql/MySqlStore.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.storehaus.mysql
 
-import com.twitter.finagle.exp.mysql.{ Client, Result, Parameter }
+import com.twitter.storehaus.mysql.compat.{Client, Result, Parameter}
 import com.twitter.storehaus.FutureOps
 import com.twitter.storehaus.Store
 import com.twitter.util.{Future, Time}

--- a/storehaus-mysql/src/main/scala/com/twitter/storehaus/mysql/ValueMapper.scala
+++ b/storehaus-mysql/src/main/scala/com/twitter/storehaus/mysql/ValueMapper.scala
@@ -17,7 +17,7 @@
 package com.twitter.storehaus.mysql
 
 import com.twitter.bijection.Injection
-import com.twitter.finagle.exp.mysql.{
+import com.twitter.storehaus.mysql.compat.{
   EmptyValue,
   IntValue,
   LongValue,

--- a/storehaus-mysql/src/test/scala/com/twitter/storehaus/mysql/MySqlLongStoreProperties.scala
+++ b/storehaus-mysql/src/test/scala/com/twitter/storehaus/mysql/MySqlLongStoreProperties.scala
@@ -16,8 +16,8 @@
 
 package com.twitter.storehaus.mysql
 
-import com.twitter.finagle.exp.Mysql
-import com.twitter.finagle.exp.mysql.Client
+import com.twitter.storehaus.mysql.compat.Mysql
+import com.twitter.storehaus.mysql.compat.Client
 import com.twitter.storehaus.testing.SelfAggregatingCloseableCleanup
 import com.twitter.storehaus.testing.generator.NonEmpty
 import com.twitter.util.{Future, Await}

--- a/storehaus-mysql/src/test/scala/com/twitter/storehaus/mysql/MySqlStoreProperties.scala
+++ b/storehaus-mysql/src/test/scala/com/twitter/storehaus/mysql/MySqlStoreProperties.scala
@@ -16,8 +16,8 @@
 
 package com.twitter.storehaus.mysql
 
-import com.twitter.finagle.exp.Mysql
-import com.twitter.finagle.exp.mysql.Client
+import com.twitter.storehaus.mysql.compat.Mysql
+import com.twitter.storehaus.mysql.compat.Client
 import com.twitter.storehaus.testing.SelfAggregatingCloseableCleanup
 import com.twitter.storehaus.testing.generator.NonEmpty
 import com.twitter.util.{Await, Future}

--- a/storehaus-redis/src/main/scala-2.10/com/twitter/storehaus/redis/compat/RedisCompatClient.scala
+++ b/storehaus-redis/src/main/scala-2.10/com/twitter/storehaus/redis/compat/RedisCompatClient.scala
@@ -1,0 +1,70 @@
+package com.twitter.storehaus.redis.compat
+
+import com.twitter.finagle.redis
+import com.twitter.finagle.redis.protocol.ZRangeResults
+import com.twitter.finagle.netty3.ChannelBufferBuf
+import com.twitter.util.Future
+import org.jboss.netty.buffer.ChannelBuffer
+
+object RedisCompatClient {
+
+  def get(client: redis.Client, k: ChannelBuffer): Future[Option[ChannelBuffer]] =
+    client.get(k)
+
+  def mGet2(client: redis.Client, ks: Seq[ChannelBuffer]): Future[Seq[Option[ChannelBuffer]]] =
+    client.mGet2(ks)
+
+  def set(client: redis.Client, k: ChannelBuffer, v: ChannelBuffer): Future[Unit] =
+    client.set(k, v)
+
+  def setEx(client: redis.Client, k: ChannelBuffer, t: Long, v: ChannelBuffer): Future[Unit] =
+    client.setEx(k, t, v)
+
+  def hGetAll(client: redis.Client, k: ChannelBuffer): Future[Seq[(ChannelBuffer, ChannelBuffer)]] =
+    client.hGetAll(k)
+
+  def hMSet(client: redis.Client, k: ChannelBuffer, m: Map[ChannelBuffer, ChannelBuffer]): Future[Unit] =
+    client.hMSet(k, m)
+
+  def expire(client: redis.Client, k: ChannelBuffer, t: Int) =
+    client.expire(new ChannelBufferBuf(k), t)
+
+  def del(client: redis.Client, ks: Seq[ChannelBuffer]) =
+    client.dels(ks map (new ChannelBufferBuf(_)))
+
+  def incrBy(client: redis.Client, k: ChannelBuffer, by: Long) =
+    client.incrBy(new ChannelBufferBuf(k), by)
+
+  def sMembers(client: redis.Client, k: ChannelBuffer): Future[Set[ChannelBuffer]] =
+    client.sMembers(k)
+
+  def sAdd(client: redis.Client, k: ChannelBuffer, vs: List[ChannelBuffer]) =
+    client.sAdd(k, vs)
+
+  def sRem(client: redis.Client, k: ChannelBuffer, vs: List[ChannelBuffer]) =
+    client.sRem(k, vs)
+
+  def sIsMember(client: redis.Client, k: ChannelBuffer, v: ChannelBuffer) =
+    client.sIsMember(k, v)
+
+  def zRange(client: redis.Client, k: ChannelBuffer, from: Long, to: Long, t: Boolean): Future[Either[ZRangeResults,Seq[ChannelBuffer]]] =
+    client.zRange(k, from, to, t)
+
+  def zRangeLeftAsTuples(client: redis.Client, k: ChannelBuffer, from: Long, to: Long, t: Boolean): Future[Option[Seq[(ChannelBuffer, Double)]]] =
+    zRange(client, k, from, to, t) map { r =>
+      r.left.toOption.map(_.asTuples).filter(_.nonEmpty)
+    }
+
+  def zIncrBy(client: redis.Client, k: ChannelBuffer, by: Double, m: ChannelBuffer) =
+    client.zIncrBy(k, by, m)
+
+  def zScore(client: redis.Client, k: ChannelBuffer, v: ChannelBuffer) =
+    client.zScore(k, v)
+
+  def zAdd(client: redis.Client, k: ChannelBuffer, s: Double, m: ChannelBuffer) =
+    client.zAdd(k, s, m)
+
+  def zRem(client: redis.Client, k: ChannelBuffer, vs: List[ChannelBuffer]) =
+    client.zRem(k, vs)
+
+}

--- a/storehaus-redis/src/main/scala-2.11/com/twitter/storehaus/redis/compat/RedisCompatClient.scala
+++ b/storehaus-redis/src/main/scala-2.11/com/twitter/storehaus/redis/compat/RedisCompatClient.scala
@@ -1,0 +1,95 @@
+package com.twitter.storehaus.redis.compat
+
+import scala.util.Either
+
+import com.twitter.finagle.redis
+import com.twitter.finagle.redis.protocol.ZRangeResults
+import com.twitter.finagle.netty3.BufChannelBuffer
+import com.twitter.finagle.netty3.ChannelBufferBuf
+import com.twitter.io.Buf
+import com.twitter.util.Future
+import org.jboss.netty.buffer.ChannelBuffer
+
+object RedisCompatClient {
+
+  def get(client: redis.Client, k: ChannelBuffer): Future[Option[ChannelBuffer]] =
+    client.get(new ChannelBufferBuf(k)) map {
+      case Some(v) => Some(BufChannelBuffer(v))
+      case _ => None
+    }
+
+  def mGet2(client: redis.Client, ks: Seq[ChannelBuffer]): Future[Seq[Option[ChannelBuffer]]] =
+    client.mGet(ks map (new ChannelBufferBuf(_))) map { vs =>
+      vs map {
+        case Some(v) => Some(BufChannelBuffer(v))
+        case None => None
+      }
+    }
+
+  def set(client: redis.Client, k: ChannelBuffer, v: ChannelBuffer): Future[Unit] =
+    client.set(new ChannelBufferBuf(k), new ChannelBufferBuf(v))
+
+  def setEx(client: redis.Client, k: ChannelBuffer, t: Long, v: ChannelBuffer): Future[Unit] =
+    client.setEx(new ChannelBufferBuf(k), t, new ChannelBufferBuf(v))
+
+  def hGetAll(client: redis.Client, k: ChannelBuffer): Future[Seq[(ChannelBuffer, ChannelBuffer)]] =
+    client.hGetAll(new ChannelBufferBuf(k)) map { m =>
+      m map { case (f, v) => (BufChannelBuffer(f), BufChannelBuffer(v)) }
+    }
+
+  def hMSet(client: redis.Client, k: ChannelBuffer, m: Map[ChannelBuffer, ChannelBuffer]): Future[Unit] = {
+    val mBuf: Map[Buf, Buf] = (m.toSeq map { case (f, v) => (new ChannelBufferBuf(f), new ChannelBufferBuf(v)) }).toMap
+    client.hMSet(new ChannelBufferBuf(k), mBuf)
+  }
+
+  def expire(client: redis.Client, k: ChannelBuffer, t: Int) =
+    client.expire(new ChannelBufferBuf(k), t)
+
+  def del(client: redis.Client, ks: Seq[ChannelBuffer]) =
+    client.dels(ks map (new ChannelBufferBuf(_)))
+
+  def incrBy(client: redis.Client, k: ChannelBuffer, by: Long) =
+    client.incrBy(new ChannelBufferBuf(k), by)
+
+  def sMembers(client: redis.Client, k: ChannelBuffer): Future[Set[ChannelBuffer]] =
+    client.sMembers(new ChannelBufferBuf(k)) map { s =>
+      s.map(BufChannelBuffer(_))
+    }
+
+  def sAdd(client: redis.Client, k: ChannelBuffer, vs: List[ChannelBuffer]) =
+    client.sAdd(new ChannelBufferBuf(k), vs map (new ChannelBufferBuf(_)))
+
+  def sRem(client: redis.Client, k: ChannelBuffer, vs: List[ChannelBuffer]) =
+    client.sRem(new ChannelBufferBuf(k), vs map (new ChannelBufferBuf(_)))
+
+  def sIsMember(client: redis.Client, k: ChannelBuffer, v: ChannelBuffer) =
+    client.sIsMember(new ChannelBufferBuf(k), new ChannelBufferBuf(v))
+
+  def zRange(client: redis.Client, k: ChannelBuffer, from: Long, to: Long, t: Boolean): Future[Either[ZRangeResults,Seq[ChannelBuffer]]] =
+    client.zRange(new ChannelBufferBuf(k), from, to, t) map {
+      case Left(zRangeResults) => Left(zRangeResults)
+      case Right(vs) => Right(vs map (BufChannelBuffer(_)))
+    }
+
+  def zRangeLeftAsTuples(client: redis.Client, k: ChannelBuffer, from: Long, to: Long, t: Boolean): Future[Option[Seq[(ChannelBuffer, Double)]]] =
+    zRange(client, k, from, to, t) map { r =>
+      r.left.toOption.map(_.asTuples).filter(_.nonEmpty) map { ts =>
+        ts map {
+          case (t, d) => (BufChannelBuffer(t), d)
+        }
+      }
+    }
+
+  def zIncrBy(client: redis.Client, k: ChannelBuffer, by: Double, m: ChannelBuffer) =
+    client.zIncrBy(new ChannelBufferBuf(k), by, new ChannelBufferBuf(m))
+
+  def zScore(client: redis.Client, k: ChannelBuffer, v: ChannelBuffer) =
+    client.zScore(new ChannelBufferBuf(k), new ChannelBufferBuf(v))
+
+  def zAdd(client: redis.Client, k: ChannelBuffer, s: Double, m: ChannelBuffer) =
+    client.zAdd(new ChannelBufferBuf(k), s, new ChannelBufferBuf(m))
+
+  def zRem(client: redis.Client, k: ChannelBuffer, vs: List[ChannelBuffer]) =
+    client.zRem(new ChannelBufferBuf(k), vs map (new ChannelBufferBuf(_)))
+
+}

--- a/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisLongStore.scala
+++ b/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisLongStore.scala
@@ -22,6 +22,7 @@ import com.twitter.bijection.netty.Implicits._
 import com.twitter.finagle.redis.Client
 import com.twitter.storehaus.ConvertedStore
 import com.twitter.storehaus.algebra.MergeableStore
+import com.twitter.storehaus.redis.compat.RedisCompatClient
 import com.twitter.util.{ Duration, Future }
 import org.jboss.netty.buffer.ChannelBuffer
 
@@ -52,5 +53,5 @@ class RedisLongStore(underlying: RedisStore)
      with MergeableStore[ChannelBuffer, Long] {
   val semigroup = implicitly[Semigroup[Long]]
   override def merge(kv: (ChannelBuffer, Long)): Future[Option[Long]] =
-    underlying.client.incrBy(kv._1, kv._2).map(v => Some(v - kv._2)) // redis returns the result
+    RedisCompatClient.incrBy(underlying.client, kv._1, kv._2).map(v => Some(v - kv._2)) // redis returns the result
 }


### PR DESCRIPTION
The main goal of this PR is to update Finagle to the new version 6.43.0 for using new and improve Finagle features and performance and also one day migrate Storehaus to Scala 2.12.

The **Scala 2.10 cross build is still kept valid** using Finagle 6.35.0 (new Finagle versions beyond 6.35.0 are not compatible with Scala 2.10 any more which includes, of course Finagle 6.43.0)

Scala 2.12 is not added to the cross builds yet, since the **Scalding dependency is not yet available for Scala 2.12** (all the other dependencies are already Scala 2.12 compatible updating their versions)