### PR TITLE
Upgrade finagle to 6.43.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,7 +192,7 @@ val bijectionVersion = "0.9.5"
 val utilVersion = "6.43.0"
 
 val scaldingVersion = "0.17.0"
-val finagleVersion = "6.44.0"
+val finagleVersion = "6.43.0"
 val scalatestVersion = "3.0.1"
 val scalaCheckVersion = "1.13.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,7 @@ val bijectionVersion = "0.9.5"
 val utilVersion = "6.43.0"
 
 val scaldingVersion = "0.17.0"
-val finagleVersion = "6.43.0"
+val finagleVersion = "6.44.0"
 val scalatestVersion = "3.0.1"
 val scalaCheckVersion = "1.13.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -188,10 +188,10 @@ lazy val noPublishSettings = Seq(
 
 val algebirdVersion = "0.13.0"
 val bijectionVersion = "0.9.5"
-val utilVersion = "6.41.0"
+val utilVersion = "6.43.0"
 
 val scaldingVersion = "0.17.0"
-val finagleVersion = "6.41.0"
+val finagleVersion = "6.43.0"
 val scalatestVersion = "3.0.1"
 val scalaCheckVersion = "1.13.4"
 
@@ -368,7 +368,6 @@ lazy val storehausBenchmark = module("benchmark")
 lazy val storehausHttp = module("http").settings(
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-http" % finagleVersion,
-    "com.twitter" %% "finagle-http-compat" % finagleVersion,
     "com.twitter" %% "bijection-netty" % bijectionVersion
   )
 ).dependsOn(storehausCore)

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,8 @@ val ignoredABIProblems = {
     exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.redis.RedisSetStore.get"),
     exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.redis.RedisSetStore.delete"),
     exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.redis.RedisSortedSetStore.get"),
-    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.redis.RedisSortedSetStore.members")
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.redis.RedisSortedSetStore.members"),
+    exclude[IncompatibleMethTypeProblem]("com.twitter.storehaus.http.HttpException.apply")
   )
 }
 

--- a/storehaus-http/src/main/scala/com/twitter/storehaus/http/HttpStore.scala
+++ b/storehaus-http/src/main/scala/com/twitter/storehaus/http/HttpStore.scala
@@ -40,9 +40,10 @@ case class HttpException(code: Int, reasonPhrase: String, content: String)
 object HttpStore {
   def apply(dest: String): HttpStore = new HttpStore(Http.newService(dest))
 
-  def toChannelBufferStore(store: Store[Buf, Buf]) : Store[ChannelBuffer, ChannelBuffer] = {
+  // Here for backward compatibility, you probably don't want to use it in new code
+  def toChannelBufferStore(store: Store[Buf, Buf]): Store[String, ChannelBuffer] = {
     implicit val bij = ChannelBuffer2BufBijection
-    store.convert(ChannelBuffer2BufBijection.apply)
+    store.convert(Buf.Utf8(_))
   }
 }
 

--- a/storehaus-http/src/main/scala/com/twitter/storehaus/http/HttpStore.scala
+++ b/storehaus-http/src/main/scala/com/twitter/storehaus/http/HttpStore.scala
@@ -17,72 +17,88 @@
 package com.twitter.storehaus.http
 
 import java.nio.charset.Charset
-import org.jboss.netty.buffer.ChannelBuffer
-import org.jboss.netty.handler.codec.http.{ HttpRequest, HttpResponse, DefaultHttpRequest,
-  HttpVersion, HttpMethod, HttpHeaders, HttpResponseStatus }
+
+import com.twitter.bijection.{Bijection, StringCodec}
+import com.twitter.finagle.http._
+import com.twitter.finagle.netty3.ChannelBufferBuf
+import com.twitter.finagle.{Http, Service}
+import com.twitter.io.Buf
+import com.twitter.storehaus.{ConvertedStore, Store}
 import com.twitter.util.Future
-import com.twitter.bijection.StringCodec
-import com.twitter.bijection.netty.ChannelBufferBijection
-import com.twitter.finagle.{ Service, Http }
-import com.twitter.finagle.http.compat.NettyClientAdaptor
-import com.twitter.storehaus.{ Store, ConvertedStore }
+import org.jboss.netty.buffer.ChannelBuffer
 
 object HttpException {
-  def apply(response: HttpResponse): HttpException =
-    new HttpException(response.getStatus.getCode, response.getStatus.getReasonPhrase,
-      response.getContent.toString(Charset.forName("UTF-8")))
+  def apply(response: Response): HttpException = {
+    new HttpException(response.status.code, response.status.reason,
+      response.contentString)
+  }
 }
 
 case class HttpException(code: Int, reasonPhrase: String, content: String)
   extends Exception(reasonPhrase + Option(content).map("\n" + _ ).getOrElse(""))
 
 object HttpStore {
-  def apply(dest: String): HttpStore =
-    new HttpStore(NettyClientAdaptor andThen Http.newService(dest))
+  def apply(dest: String): HttpStore = new HttpStore(Http.newService(dest))
+
+  def toChannelBufferStore(store: Store[Buf, Buf]) : Store[ChannelBuffer, ChannelBuffer] = {
+    implicit val bij = ChannelBuffer2BufBijection
+    store.convert(ChannelBuffer2BufBijection.apply)
+  }
 }
 
-class HttpStore(val client: Service[HttpRequest, HttpResponse])
-    extends Store[String, ChannelBuffer] {
-  override def get(k: String): Future[Option[ChannelBuffer]] = {
-    val request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, k)
-    request.headers.set(HttpHeaders.Names.CONTENT_LENGTH, "0")
+object ChannelBuffer2BufBijection extends Bijection[ChannelBuffer, Buf] {
+  def apply(c: ChannelBuffer): Buf = ChannelBufferBuf.newOwned(c)
+  override def invert(m: Buf): ChannelBuffer = ChannelBufferBuf.Owned.extract(m)
+}
+
+class HttpStore(val client: Service[Request, Response])
+    extends Store[String, Buf] {
+
+  override def get(k: String): Future[Option[Buf]] = {
+    val request = Request(Method.Get, k)
+    request.contentLength = 0
     client(request).map{ response =>
-      response.getStatus match {
-        case HttpResponseStatus.OK => Some(response.getContent)
-        case HttpResponseStatus.NOT_FOUND => None
+      response.status match {
+        case Status.Ok => Some(response.content)
+        case Status.NotFound => None
         case _ => throw HttpException(response)
       }
     }
   }
 
-  override def put(kv: (String, Option[ChannelBuffer])): Future[Unit] = {
+  override def put(kv: (String, Option[Buf])): Future[Unit] = {
     val request = kv match {
-      case (k, Some(cb)) =>
-        val req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, k)
-        req.setContent(cb)
-        req.headers.set(HttpHeaders.Names.CONTENT_LENGTH, cb.readableBytes.toString)
+      case (k, Some(buf)) =>
+        val req = Request(Method.Put, k)
+        req.content = buf
+        req.contentLength = buf.length
         req
       case (k, None) =>
-        val req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.DELETE, k)
-        req.headers.set(HttpHeaders.Names.CONTENT_LENGTH, "0")
+        val req = Request(Method.Delete, k)
+        req.contentLength = 0
         req
     }
     client(request).map{ response =>
-      response.getStatus match {
-        case HttpResponseStatus.OK => ()
-        case HttpResponseStatus.CREATED => ()
-        case HttpResponseStatus.NO_CONTENT => ()
+      response.status match {
+        case Status.Ok => ()
+        case Status.Created => ()
+        case Status.NoContent => ()
         case _ => throw HttpException(response)
       }
     }
   }
+}
+
+object BufBijection extends Bijection[Buf, Array[Byte]] {
+  override def apply(buf: Buf) = Buf.ByteArray.Owned.extract(buf)
+  override def invert(ary: Array[Byte]) = Buf.ByteArray.Owned(ary)
 }
 
 object HttpStringStore {
   def apply(dest: String): HttpStringStore =
-    new HttpStringStore(NettyClientAdaptor andThen Http.newService(dest))
+    new HttpStringStore(Http.newService(dest))
 }
 
-class HttpStringStore(val client: Service[HttpRequest, HttpResponse])
-    extends ConvertedStore[String, String, ChannelBuffer, String](
-      new HttpStore(client))(identity)(StringCodec.utf8 andThen ChannelBufferBijection.inverse)
+class HttpStringStore(val client: Service[Request, Response])
+    extends ConvertedStore[String, String, Buf, String](
+      new HttpStore(client))(identity)(StringCodec.utf8 andThen BufBijection.inverse)

--- a/storehaus-http/src/test/scala/com/twitter/storehaus/http/HttpStringStoreProperties.scala
+++ b/storehaus-http/src/test/scala/com/twitter/storehaus/http/HttpStringStoreProperties.scala
@@ -72,7 +72,7 @@ object HttpStringStoreProperties
           Option(map.get(request.uri)).map{ v =>
             val resp = Response(request.version, Status.Ok)
             resp.contentString = v
-            resp.contentLength = v.getBytes.size
+            resp.contentLength = v.getBytes(utf8).size
             resp
           }.getOrElse {
             val resp = Response(request.version, Status.NotFound)

--- a/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisStore.scala
+++ b/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisStore.scala
@@ -41,12 +41,13 @@ object RedisStore {
     new RedisStore(client, ttl)
 
   def toChannelBufferStore(store: Store[Buf, Buf]) : Store[ChannelBuffer, ChannelBuffer] = {
-    implicit val bij = ChannelBuffer2BufInjection
-    store.convert(ChannelBuffer2BufInjection.apply)
+    implicit val bij = ChannelBuffer2BufBijection
+    store.convert(ChannelBuffer2BufBijection.apply)
   }
 }
 
-object ChannelBuffer2BufInjection extends Bijection[ChannelBuffer, Buf] {
+// todo: This also exists in storehaus-http, remove duplication
+object ChannelBuffer2BufBijection extends Bijection[ChannelBuffer, Buf] {
   def apply(c: ChannelBuffer): Buf = ChannelBufferBuf.newOwned(c)
   override def invert(m: Buf): ChannelBuffer = ChannelBufferBuf.Owned.extract(m)
 }

--- a/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisStore.scala
+++ b/storehaus-redis/src/main/scala/com/twitter/storehaus/redis/RedisStore.scala
@@ -40,7 +40,7 @@ object RedisStore {
   def apply(client: Client, ttl: Option[Duration] = Default.TTL): RedisStore =
     new RedisStore(client, ttl)
 
-  def toChannelBufferStore(store: Store[Buf, Buf]) : Store[ChannelBuffer, ChannelBuffer] = {
+  def toChannelBufferStore(store: Store[Buf, Buf]): Store[ChannelBuffer, ChannelBuffer] = {
     implicit val bij = ChannelBuffer2BufBijection
     store.convert(ChannelBuffer2BufBijection.apply)
   }


### PR DESCRIPTION
Upgrades finagle and twitter util. In the process gets rid of finagle-http-compat and moves to the latest finagle http api.