### PR TITLE
Release 0.15.0 prep. Update version in preparation for rc release.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15.0-SNAPSHOT"
+version in ThisBuild := "0.15.0-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15.0-RC2"
+version in ThisBuild := "0.15.0"


### PR DESCRIPTION
Proposed release notes:
* Add support for scala 2.12 #346 
* Update finagle to 6.43.0 #347 

Note that this release drops support for anything before jdk8. Upstream libs finagle and util have already done so.
