### PR TITLE
Replace usage of deprecated util conversion methods.

### DIFF
--- a/storehaus-benchmark/src/main/scala/com/twitter/storehaus/benchmark/WriteThroughCacheBenchmark.scala
+++ b/storehaus-benchmark/src/main/scala/com/twitter/storehaus/benchmark/WriteThroughCacheBenchmark.scala
@@ -3,7 +3,6 @@ package benchmark
 
 
 import com.twitter.bijection._
-import com.twitter.conversions.time._
 import com.twitter.algebird._
 import com.twitter.storehaus.cache.{
   RollOverFrequencyMS, WriteOperationUpdateFrequency,
@@ -16,21 +15,21 @@ import org.openjdk.jmh.annotations._
 
 class DelayedStore[K, V](val self: Store[K, V])(implicit timer: Timer) extends StoreProxy[K, V] {
   override def put(kv: (K, Option[V])): Future[Unit] = {
-    self.put(kv).delayed(10.milliseconds)
+    self.put(kv).delayed(Duration.fromMilliseconds(10))
   }
 
   override def get(kv: K): Future[Option[V]] = {
-    self.get(kv).delayed(10.milliseconds)
+    self.get(kv).delayed(Duration.fromMilliseconds(10))
   }
 
   override def multiGet[K1 <: K](ks: Set[K1]): Map[K1, Future[Option[V]]] =
     self.multiGet(ks).map { case (k, v) =>
-      (k, v.delayed(10.milliseconds))
+      (k, v.delayed(Duration.fromMilliseconds(10)))
     }
 
   override def multiPut[K1 <: K](kvs: Map[K1, Option[V]]): Map[K1, Future[Unit]] =
     self.multiPut(kvs).map { case (k, v) =>
-      (k, v.delayed(10.milliseconds))
+      (k, v.delayed(Duration.fromMilliseconds(10)))
     }
 }
 

--- a/storehaus-cache/src/test/scala/com/twitter/storehaus/cache/CacheProperties.scala
+++ b/storehaus-cache/src/test/scala/com/twitter/storehaus/cache/CacheProperties.scala
@@ -18,7 +18,7 @@ package com.twitter.storehaus.cache
 
 import org.scalacheck.{Prop, Arbitrary, Properties}
 import org.scalacheck.Prop._
-import com.twitter.conversions.time._
+import com.twitter.util.Duration
 
 object CacheProperties extends Properties("Cache") {
   /**
@@ -62,5 +62,5 @@ object CacheProperties extends Properties("Cache") {
 
   property("LRUCache obeys the cache laws") = cacheLaws(LRUCache[String, Int](10))
   property("LIRSCache obeys the cache laws") = cacheLaws(LIRSCache[String, Int](10, .8))
-  property("TTLCache obeys the cache laws") = cacheLaws(TTLCache[String, Int](10.milliseconds))
+  property("TTLCache obeys the cache laws") = cacheLaws(TTLCache[String, Int](Duration.fromMilliseconds(10)))
 }

--- a/storehaus-cache/src/test/scala/com/twitter/storehaus/cache/MutableTTLCacheProperties.scala
+++ b/storehaus-cache/src/test/scala/com/twitter/storehaus/cache/MutableTTLCacheProperties.scala
@@ -19,7 +19,7 @@ package com.twitter.storehaus.cache
 import org.scalacheck.{ Arbitrary, Properties }
 import org.scalacheck.Gen.choose
 import org.scalacheck.Prop._
-import com.twitter.conversions.time._
+import com.twitter.util.Duration
 
 object MutableTTLCacheProperties extends Properties("MutableTTLCache") {
   case class PositiveTTLTime(get: Long)
@@ -42,7 +42,7 @@ object MutableTTLCacheProperties extends Properties("MutableTTLCache") {
 
   property("If insert an item with a TTL of X, and wait X + delta then it cannot be there") =
     forAll { (ttl: PositiveTTLTime, items: List[Long]) =>
-      val cache = MutableCache.ttl[Long, Long](ttl.get.milliseconds, items.size)
+      val cache = MutableCache.ttl[Long, Long](Duration.fromMilliseconds(ttl.get), items.size)
       items.foreach(item => cache += ((item, item)))
       spinSleep(ttl.get + 40)
       items.iterator.forall(item => cache.get(item).isEmpty)
@@ -51,7 +51,7 @@ object MutableTTLCacheProperties extends Properties("MutableTTLCache") {
   property("if you put with TTL t, and wait 0 time, it should always " +
       "(almost, except due to scheduling) be in there") =
     forAll { (ttl: NegativeTTLTime, items: List[Long]) =>
-      val cache = MutableCache.ttl[Long, Long](ttl.get.milliseconds, items.size)
+      val cache = MutableCache.ttl[Long, Long](Duration.fromMilliseconds(ttl.get), items.size)
       items.foreach(item => cache += ((item, item)))
       items.forall(item => cache.get(item).isDefined)
     }

--- a/storehaus-core/src/main/scala/com/twitter/storehaus/RetryingStore.scala
+++ b/storehaus-core/src/main/scala/com/twitter/storehaus/RetryingStore.scala
@@ -16,7 +16,6 @@
 
 package com.twitter.storehaus
 
-import com.twitter.conversions.time._
 import com.twitter.util._
 
 /**
@@ -57,7 +56,7 @@ class RetryingStore[-K, V](
   (implicit timer: Timer)
   extends RetryingReadableStore[K, V](store, backoffs)(pred) with Store[K, V] {
 
-  private val paddedBackoffs = backoffs ++ Seq(0.second)
+  private val paddedBackoffs = backoffs ++ Seq(Duration.Zero)
 
   private def find[T](futures: Iterator[(Future[T], Duration)])(pred: T => Boolean): Future[T] = {
     if (!futures.hasNext) {

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/RetryingReadableStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/RetryingReadableStoreProperties.scala
@@ -16,7 +16,7 @@
 
 package com.twitter.storehaus
 
-import com.twitter.util.{JavaTimer, Timer}
+import com.twitter.util.{Duration, JavaTimer, Timer}
 import java.util.Random
 import org.scalacheck.Properties
 

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/RetryingReadableStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/RetryingReadableStoreProperties.scala
@@ -16,7 +16,6 @@
 
 package com.twitter.storehaus
 
-import com.twitter.conversions.time._
 import com.twitter.util.{JavaTimer, Timer}
 import java.util.Random
 import org.scalacheck.Properties
@@ -39,7 +38,7 @@ object RetryingReadableStoreProperties extends Properties("RetryingStore") {
     readableStoreLaws[Int, String] { m =>
       ReadableStore.withRetry(
         store = ReadableStore.fromFn(fromMapWithRandomLatency(2)(m)),
-        backoffs = for (i <- 0 until 3) yield 1.milliseconds
+        backoffs = for (i <- 0 until 3) yield Duration.fromMilliseconds(1)
       )(_ => true)
     }
 }

--- a/storehaus-core/src/test/scala/com/twitter/storehaus/RetryingStoreProperties.scala
+++ b/storehaus-core/src/test/scala/com/twitter/storehaus/RetryingStoreProperties.scala
@@ -16,8 +16,7 @@
 
 package com.twitter.storehaus
 
-import com.twitter.conversions.time._
-import com.twitter.util.{JavaTimer, Timer}
+import com.twitter.util.{Duration, JavaTimer, Timer}
 
 import org.scalacheck.Properties
 
@@ -31,7 +30,7 @@ object RetryingStoreProperties extends Properties("RetryingStore") {
     storeTest[String, Int] {
       Store.withRetry[String, Int](
         store = new ConcurrentHashMapStore[String, Int](),
-        backoffs = for (i <- 0 until 3) yield 1.milliseconds
+        backoffs = for (i <- 0 until 3) yield Duration.fromMilliseconds(1)
       )(_ => true)
     }
 }

--- a/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
+++ b/storehaus-memcache/src/main/scala/com/twitter/storehaus/memcache/MemcacheStore.scala
@@ -19,7 +19,6 @@ package com.twitter.storehaus.memcache
 import com.twitter.algebird.Semigroup
 import com.twitter.bijection.{Codec, Injection}
 import com.twitter.bijection.netty.Implicits._
-import com.twitter.conversions.time._
 import com.twitter.finagle.builder.ClientBuilder
 import com.twitter.finagle.memcached.KetamaClientBuilder
 import com.twitter.finagle.memcached.protocol.text.Memcached
@@ -31,6 +30,7 @@ import com.twitter.storehaus.algebra.MergeableStore
 import org.jboss.netty.buffer.ChannelBuffer
 import Store.enrich
 import com.twitter.finagle.transport.Transport
+import java.util.concurrent.TimeUnit
 
 /**
  *  @author Oscar Boykin
@@ -43,7 +43,7 @@ object MemcacheStore {
   // Default Memcached TTL is one day.
   // For more details of setting expiration time for items in Memcached, please refer to
   // https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L79
-  val DEFAULT_TTL = 1.day
+  val DEFAULT_TTL = Duration(1, TimeUnit.DAYS)
 
   // This flag used on "set" operations. Search this page for "flag"
   // for more info on the following variable:
@@ -51,7 +51,7 @@ object MemcacheStore {
   val DEFAULT_FLAG = 0
 
   val DEFAULT_CONNECTION_LIMIT = 1
-  val DEFAULT_TIMEOUT = 1.seconds
+  val DEFAULT_TIMEOUT = Duration(1, TimeUnit.SECONDS)
   val DEFAULT_RETRIES = 2
 
   def apply(


### PR DESCRIPTION
Problem

As of util commit https://github.com/twitter/util/commit/ee56e5f2418d5d6540d37268436ff6f47520edaf the conversions are deprecated.

Solution

Avoid these conversion methods.