### PR TITLE
Update finagle version to 7.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ val sharedSettings = extraSettings ++ ciSettings ++ Seq(
     "Conjars Repository" at "http://conjars.org/repo",
     // this repo is needed to retrieve the excluded dependencies from storehaus-memcache
     // during mima checks
-    "Twitter Maven" at "http://maven.twttr.com"
+    "Twitter Maven" at "https://maven.twttr.com"
   ),
   parallelExecution in Test := true,
   scalacOptions ++= Seq(
@@ -133,10 +133,10 @@ lazy val noPublishSettings = Seq(
 
 val algebirdVersion = "0.13.0"
 val bijectionVersion = "0.9.5"
-val utilVersion = "6.43.0"
+val utilVersion = "7.0.0"
 
 val scaldingVersion = "0.17.0"
-val finagleVersion = "6.43.0"
+val finagleVersion = "7.0.0"
 val scalatestVersion = "3.0.1"
 val scalaCheckVersion = "1.13.4"
 
@@ -206,14 +206,18 @@ lazy val storehausMemcache = module("memcache").settings(
 ).dependsOn(storehausAlgebra % "test->test;compile->compile")
 
 lazy val storehausMySQL = module("mysql").settings(
-  libraryDependencies += "com.twitter" %% "finagle-mysql" % finagleVersion
+  libraryDependencies ++= Seq(
+    "com.twitter" %% "finagle-mysql" % finagleVersion,
+    "com.twitter" %% "finagle-netty3" % finagleVersion
+  )
 ).dependsOn(storehausAlgebra % "test->test;compile->compile")
 
 lazy val storehausRedis = module("redis").settings(
   libraryDependencies ++= Seq (
     "com.twitter" %% "bijection-core" % bijectionVersion,
     "com.twitter" %% "bijection-netty" % bijectionVersion,
-    "com.twitter" %% "finagle-redis" % finagleVersion
+    "com.twitter" %% "finagle-redis" % finagleVersion,
+    "com.twitter" %% "finagle-netty3" % finagleVersion
   ),
   // we don't want various tests clobbering each others keys
   parallelExecution in Test := false

--- a/storehaus-memcache/src/test/scala/com/twitter/storehaus/memcache/MergeableMemcacheStoreProperties.scala
+++ b/storehaus-memcache/src/test/scala/com/twitter/storehaus/memcache/MergeableMemcacheStoreProperties.scala
@@ -19,7 +19,7 @@ package com.twitter.storehaus.memcache
 import com.twitter.algebird.Semigroup
 import com.twitter.bijection.Injection
 import com.twitter.bijection.netty.ChannelBufferBijection
-import com.twitter.finagle.memcached.Client
+import com.twitter.finagle.Memcached
 import com.twitter.storehaus.testing.SelfAggregatingCloseableCleanup
 import com.twitter.storehaus.testing.generator.NonEmpty
 import com.twitter.util.{Future, Await}
@@ -87,7 +87,7 @@ object MergeableMemcacheStoreProperties extends Properties("MergeableMemcacheSto
 
   property("MergeableMemcacheStore put, get and merge") = {
     implicit val cb2ary = ChannelBufferBijection
-    val client = Client("localhost:11211")
+    val client = Memcached.client.newRichClient("localhost:11211")
     val injection = Injection.connect[Long, String, Array[Byte], ChannelBuffer]
     val semigroup = implicitly[Semigroup[Long]]
     val store = MergeableMemcacheStore[String, Long](client)(identity)(injection, semigroup)


### PR DESCRIPTION
Replaced Ketama client with Memcache client

Bumped finagle version to 7.0.0
`client.release()` method was deprecated and in latest version of finagle release method was removed. 7.0 is the earliest version with close method available.

Also `KetamaClientBuilder` was removed from 7.0 hence replacing it with `Memcached.client`. Destination path for both KetamaClient and Memcached client is same, hence the same `nodeString` works.